### PR TITLE
docs: Fix issue with getting started

### DIFF
--- a/docs/source/home/getting-started.md
+++ b/docs/source/home/getting-started.md
@@ -14,14 +14,15 @@ sudo apt-get install -y gh git curl direnv
 ```
 
 3. Log into GitHub: `gh auth login -w -p https`
-4. Clone the repo (into `~/perseus-v2`):
+4. Clone the repo (into `~/perseus-v2`) and `cd` into it:
 
 ```{code-block} console
 cd ~
 gh repo clone ROAR-QUTRC/perseus-v2 # download the repository
+cd perseus-v2
 ```
 
-5. Run the setup script (it will prompt you for sudo permissions): `~/perseus-v2/software/scripts/nix-setup.sh`
+5. Run the setup script (it will prompt you for sudo permissions): `./software/scripts/nix-setup.sh`
 6. Restart your shell
 7. Run `cd ~/perseus-v2`
 8. Accept all config options when prompted with `y`


### PR DESCRIPTION
The cwd needs to be the repo when you run the getting-started script.