### PR TITLE
autonomy: CMakeLists.txt and launch file project aligned

### DIFF
--- a/software/ros_ws/nix-packages/input-devices.nix
+++ b/software/ros_ws/nix-packages/input-devices.nix
@@ -7,7 +7,6 @@
   ament-pep257,
   geometry-msgs,
   python3Packages,
-  pythonPackages,
   rclpy,
   sensor-msgs,
 }:
@@ -23,7 +22,7 @@ buildRosPackage rec {
     ament-copyright
     ament-flake8
     ament-pep257
-    pythonPackages.pytest
+    python3Packages.pytest
   ];
   propagatedBuildInputs = [
     geometry-msgs

--- a/software/ros_ws/nix-packages/overlay.nix
+++ b/software/ros_ws/nix-packages/overlay.nix
@@ -1,8 +1,8 @@
-self: super: {
-  autonomy = super.callPackage ./autonomy.nix { };
-  input-devices = super.callPackage ./input-devices.nix { };
-  perseus = super.callPackage ./perseus.nix { };
-  perseus-description = super.callPackage ./perseus-description.nix { };
-  perseus-hardware = super.callPackage ./perseus-hardware.nix { };
-  perseus-sensors = super.callPackage ./perseus-sensors.nix { };
+final: prev: {
+  autonomy = final.callPackage ./autonomy.nix { };
+  input-devices = final.callPackage ./input-devices.nix { };
+  perseus = final.callPackage ./perseus.nix { };
+  perseus-description = final.callPackage ./perseus-description.nix { };
+  perseus-hardware = final.callPackage ./perseus-hardware.nix { };
+  perseus-sensors = final.callPackage ./perseus-sensors.nix { };
 }


### PR DESCRIPTION
Note that this code pre-dated the software standards so PR is mostly a 'bugfix' to bring code up to standard ahead of future feature to undertake map creation with lidar.

* Updated the CMakeLists.txt to be more aligned with the Perseus project format
* Updated the launch file to align with the Perseus project format.
* Added the slam_toolbox dependencies
* Update RViz2 config with laserscan topic
* Update readme with info about how to run without Perseus hardware