### PR TITLE
Autonomy: CMakeLists.txt and launch file aligned with Project

### DIFF
--- a/software/ros_ws/nix-packages/autonomy.nix
+++ b/software/ros_ws/nix-packages/autonomy.nix
@@ -8,6 +8,7 @@
   nav2-bringup,
   rclcpp,
   slam-toolbox,
+  xacro,
 }:
 buildRosPackage rec {
   pname = "ros-jazzy-autonomy";
@@ -25,6 +26,7 @@ buildRosPackage rec {
     nav2-bringup
     rclcpp
     slam-toolbox
+    xacro
   ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/software/ros_ws/nix-packages/input-devices.nix
+++ b/software/ros_ws/nix-packages/input-devices.nix
@@ -7,7 +7,6 @@
   ament-pep257,
   geometry-msgs,
   python3Packages,
-  pythonPackages,
   rclpy,
   sensor-msgs,
 }:
@@ -23,7 +22,7 @@ buildRosPackage rec {
     ament-copyright
     ament-flake8
     ament-pep257
-    pythonPackages.pytest
+    python3Packages.pytest
   ];
   propagatedBuildInputs = [
     geometry-msgs

--- a/software/ros_ws/nix-packages/overlay.nix
+++ b/software/ros_ws/nix-packages/overlay.nix
@@ -1,8 +1,8 @@
-self: super: {
-  autonomy = super.callPackage ./autonomy.nix { };
-  input-devices = super.callPackage ./input-devices.nix { };
-  perseus = super.callPackage ./perseus.nix { };
-  perseus-description = super.callPackage ./perseus-description.nix { };
-  perseus-hardware = super.callPackage ./perseus-hardware.nix { };
-  perseus-sensors = super.callPackage ./perseus-sensors.nix { };
+final: prev: {
+  autonomy = final.callPackage ./autonomy.nix { };
+  input-devices = final.callPackage ./input-devices.nix { };
+  perseus = final.callPackage ./perseus.nix { };
+  perseus-description = final.callPackage ./perseus-description.nix { };
+  perseus-hardware = final.callPackage ./perseus-hardware.nix { };
+  perseus-sensors = final.callPackage ./perseus-sensors.nix { };
 }

--- a/software/ros_ws/src/autonomy/CMakeLists.txt
+++ b/software/ros_ws/src/autonomy/CMakeLists.txt
@@ -1,5 +1,10 @@
-cmake_minimum_required(VERSION 3.8)
-project(autonomy)
+# PROJECT SETUP
+cmake_minimum_required(VERSION 3.23)
+
+project(
+  autonomy
+  VERSION 0.0.1
+  LANGUAGES CXX)
 
 # credit https://www.kitware.com/cmake-and-the-default-build-type/
 set(default_build_type "Debug")
@@ -14,27 +19,21 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
                                                "MinSizeRel" "RelWithDebInfo")
 endif()
+# we always want debug info for stack tracing, so switch to RelWithDebInfo from
+# Release
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-# Add -Werror flag for release builds
-if(CMAKE_BUILD_TYPE MATCHES "Rel.*")
-  add_compile_options(-Werror)
-endif()
+find_package(ament_cmake)
 
-# find dependencies
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(slam_toolbox REQUIRED)
-find_package(nav2_bringup REQUIRED)
+# Install the package's resource files These directories will only be installed
+# if they exist
+install(
+  DIRECTORY launch config rviz params maps
+  DESTINATION share/${PROJECT_NAME}
+  OPTIONAL)
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
+# ROS FINALISATION
 ament_package()

--- a/software/ros_ws/src/autonomy/README.md
+++ b/software/ros_ws/src/autonomy/README.md
@@ -1,5 +1,11 @@
 ## Autonomy Package
 
+To run without actual Perseus hardware set use_mock_hardware to true when launching:
+
+```
+ros2 launch autonomy mapping_using_slam_toolbox.launch.py use_mock_hardware:=true
+```
+
 This ROS2 package is intended to cover functionality to:
 
 - create maps of the locally experienced environment from sensor data (lidar and depth cameras)

--- a/software/ros_ws/src/autonomy/package.xml
+++ b/software/ros_ws/src/autonomy/package.xml
@@ -4,7 +4,8 @@
   <name>autonomy</name>
   <version>0.0.1</version>
   <description>ROAR Autonomy software control stack</description>
-  <maintainer email="dingo.australia@gmail.com">Nigel</maintainer>
+  <maintainer email="1388693+DingoOz@users.noreply.github.com">Nigel H-S</maintainer>
+  
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -12,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>slam_toolbox</depend>
   <depend>nav2_bringup</depend>
+  <depend>xacro</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
The Autonomy code existed before the Perseus Project Software Standards. This is a fix to make the CMakeLists.txt and launch file more aligned with project formatting and approach and housing keeping on package.xml and README.md.

This update of legacy code is to support a separate future feature for slam toolbox based mapping. 