### PR TITLE
Implement LIDAR in Gazebo

### DIFF
--- a/software/ros_ws/src/perseus/launch/robot_state_publisher.launch.py
+++ b/software/ros_ws/src/perseus/launch/robot_state_publisher.launch.py
@@ -6,6 +6,7 @@ from launch.substitutions import (
     LaunchConfiguration,
 )
 
+from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -20,20 +21,22 @@ def generate_launch_description():
     robot_description_xacro = PathJoinSubstitution(
         [FindPackageShare("perseus"), "urdf", "perseus.urdf.xacro"]
     )
-    robot_description_content = Command(
-        [
-            FindExecutable(name="xacro"),
-            " ",
-            robot_description_xacro,
-            " use_sim:=",
-            use_sim_time,
-            " hardware_plugin:=",
-            hardware_plugin,
-            " can_bus:=",
-            can_bus,
-        ]
+    robot_description_content = ParameterValue(
+        Command(
+            [
+                FindExecutable(name="xacro"),
+                " ",
+                robot_description_xacro,
+                " use_sim:=",
+                use_sim_time,
+                " hardware_plugin:=",
+                hardware_plugin,
+                " can_bus:=",
+                can_bus,
+            ]
+        ),
+        value_type=str,
     )
-
     # NODES
     robot_state_publisher = Node(
         package="robot_state_publisher",

--- a/software/ros_ws/src/perseus_description/rviz/view_odom.rviz
+++ b/software/ros_ws/src/perseus_description/rviz/view_odom.rviz
@@ -8,6 +8,7 @@ Panels:
         - /Status1
         - /Grid1
         - /RobotModel1
+        - /LaserScan1
       Splitter Ratio: 0.6147058606147766
     Tree Height: 555
   - Class: rviz_common/Selection
@@ -28,7 +29,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: ""
+    SyncSource: LaserScan
 Visualization Manager:
   Class: ""
   Displays:
@@ -107,6 +108,10 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        laser_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         left_rocker:
           Alpha: 1
           Show Axes: false
@@ -145,6 +150,40 @@ Visualization Manager:
       Update Interval: 0
       Value: true
       Visual Enabled: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 0
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: LaserScan
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.10000000149011612
+      Style: Spheres
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /scan
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -227,5 +266,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1200
-  X: 1389
-  Y: 139
+  X: 1400
+  Y: 140

--- a/software/ros_ws/src/perseus_description/urdf/perseus.urdf.xacro
+++ b/software/ros_ws/src/perseus_description/urdf/perseus.urdf.xacro
@@ -4,7 +4,7 @@
     <!-- Import components -->
     <xacro:include filename="$(find perseus_description)/urdf/chassis.urdf.xacro"/>
     <xacro:include filename="$(find perseus_description)/urdf/rocker.urdf.xacro"/>
-    <!-- <xacro:include filename="$(find perseus_description)/urdf/sensors.urdf.xacro"/> -->
+    <xacro:include filename="$(find perseus_description)/urdf/sensors.urdf.xacro"/>
 
     <link name="${prefix}base_link"/>
 
@@ -25,5 +25,7 @@
     <xacro:rocker side="right">
       <origin xyz="0.275 -0.075 0.05" rpy="0.0 0.0 ${-pi/2}"/>
     </xacro:rocker>
+    <xacro:sensors>
+    </xacro:sensors>
   </xacro:macro>
 </robot>

--- a/software/ros_ws/src/perseus_description/urdf/sensors.urdf.xacro
+++ b/software/ros_ws/src/perseus_description/urdf/sensors.urdf.xacro
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" >
+  <xacro:macro name="sensors" params="prefix:=^">
+    <link name="${prefix}laser_frame">
+        <visual>
+            <origin xyz="0 0 0"/>
+            <geometry>
+                <cylinder radius="0.06" length="0.06"/>
+            </geometry>
+            <material name="black"/>
+        </visual>
+        <collision>
+            <geometry>
+                <cylinder radius="0.06" length="0.06"/>
+            </geometry>
+        </collision>
+    </link>
+
+    <joint name="${prefix}laser_joint" type="fixed">
+        <parent link="${prefix}chassis"/>
+        <child link="${prefix}laser_frame"/>
+        <origin xyz="0 0 0.23" rpy="0 0 0"/>
+    </joint>
+
+    <gazebo reference="${prefix}laser_frame">
+        <material>Gazebo/Black</material>
+        <sensor name="laser" type="gpu_lidar">
+            <pose>0 0 0 0 0 0</pose>
+            <visualize>true</visualize>
+            <update_rate>10</update_rate>
+            <topic>scan</topic>
+            <ray>
+                <scan>
+                    <horizontal>
+                        <samples>360</samples>
+                        <min_angle>-3.14</min_angle>
+                        <max_angle>3.14</max_angle>
+                    </horizontal>
+                    <!-- vertical scan probably requires some kind of pointcloud, laserscan message doesn't show in rviz -->
+                    <!-- <vertical>
+                        <samples>10</samples>
+                        <resolution>1</resolution>
+                        <min_angle>0</min_angle>
+                        <max_angle>1.03</max_angle> 
+                    </vertical> -->
+                </scan>
+                <range>
+                    <min>0.3</min>
+                    <max>12</max>
+                </range>
+            </ray>
+            <gz_frame_id>${prefix}laser_frame</gz_frame_id>
+        </sensor>
+    </gazebo>
+
+    <gazebo reference="${prefix}chassis">
+        <material>Gazebo/Grey</material>
+        <sensor name="imu_sensor" type="imu">
+            <always_on>1</always_on>
+            <update_rate>10</update_rate>
+            <visualize>true</visualize>
+            <topic>imu</topic>
+        </sensor>
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/software/ros_ws/src/perseus_description/urdf/wheel.urdf.xacro
+++ b/software/ros_ws/src/perseus_description/urdf/wheel.urdf.xacro
@@ -20,13 +20,35 @@
         <geometry>
           <cylinder length="0.115" radius="0.145" />
         </geometry>
-        <contact>
-          <lateral_friction value="0.8"/>
-          <rolling_friction value="0.1"/>
-          <spinning_friction value="0.1"/>
-        </contact>
       </collision>
     </link>
+    <!-- we need to use the gazebo tag to add in properties normally only found in SDF files -->
+    <gazebo reference="${prefix}${end}_${side}_wheel">
+      <!-- TODO: Fix the material tag (this isn't the proper way to do it, and spits out warnings) -->
+      <material>Gazebo/Orange</material>
+      <!-- see http://sdformat.org/spec?ver=1.12&elem=collision -->
+      <collision>
+        <surface>
+            <friction>
+                <ode>
+                    <!--
+                    In this case, the wheels need lower sideways than forwards coefficients of friction
+                    so that the rover can turn (skid steer) -->
+                    <!-- forward coefficient of friction -->
+                    <mu>1</mu>
+                    <!-- perpendicular coefficient of friction -->
+                    <mu2>0.3</mu2>
+                    <!--
+                    However, since mu/mu2 are normally relative to world coordinates,
+                    the rover would only be able to turn 90 degrees either way before they swapped, making turning impossible.
+                    To solve this, we need to specify the direction that mu/mu2 are relative to.
+                    -->
+                    <fdir1>1 0 0</fdir1>
+                </ode>
+            </friction>
+        </surface>
+      </collision>
+    </gazebo>
 
     <joint name="${prefix}${end}_${side}_wheel_joint" type="continuous">
       <xacro:if value="${side == 'left'}">

--- a/software/ros_ws/src/perseus_simulation/config/gz_bridge.yaml
+++ b/software/ros_ws/src/perseus_simulation/config/gz_bridge.yaml
@@ -20,3 +20,14 @@
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
+# sensors
+- ros_topic_name: "scan"
+  gz_topic_name: "scan"
+  ros_type_name: "sensor_msgs/msg/LaserScan"
+  gz_type_name: "gz.msgs.LaserScan"
+  direction: GZ_TO_ROS
+- ros_topic_name: "imu"
+  gz_topic_name: "imu"
+  ros_type_name: "sensor_msgs/msg/Imu"
+  gz_type_name: "gz.msgs.IMU"
+  direction: GZ_TO_ROS

--- a/software/ros_ws/src/perseus_simulation/launch/gazebo.launch.py
+++ b/software/ros_ws/src/perseus_simulation/launch/gazebo.launch.py
@@ -1,5 +1,5 @@
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, OpaqueFunction
+from launch.actions import ExecuteProcess, OpaqueFunction, DeclareLaunchArgument
 from launch.substitutions import (
     PathJoinSubstitution,
     LaunchConfiguration,
@@ -20,6 +20,16 @@ def generate_launch_description():
     gz_world_path = PathJoinSubstitution(
         [FindPackageShare("perseus_simulation"), "worlds", gz_world]
     )
+
+    arguments = [
+        DeclareLaunchArgument(
+            "gz_world",
+            default_value=PathJoinSubstitution(
+                [FindPackageShare("perseus_simulation"), "worlds", gz_world]
+            ),
+            description="The world file from `perseus_simulation` to use",
+        ),
+    ]
 
     # IMPORTED LAUNCH FILES
     def gz_launch(context):
@@ -98,4 +108,4 @@ def generate_launch_description():
         gz_spawn_entity,
     ]
 
-    return LaunchDescription(launch_files + nodes)
+    return LaunchDescription(arguments + launch_files + nodes)

--- a/software/ros_ws/src/perseus_simulation/worlds/empty.sdf
+++ b/software/ros_ws/src/perseus_simulation/worlds/empty.sdf
@@ -1,0 +1,88 @@
+<?xml version="1.0" ?>
+<sdf version="1.8">
+    <world name="empty">
+        <physics name="1ms" type="ignored">
+            <max_step_size>0.001</max_step_size>
+            <real_time_factor>1.0</real_time_factor>
+        </physics>
+
+        <plugin filename="libgz-sim-physics-system" name="gz::sim::systems::Physics" />
+        <plugin filename="libgz-sim-user-commands-system" name="gz::sim::systems::UserCommands" />
+        <plugin filename="libgz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster" />
+        <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
+            <render_engine>ogre2</render_engine>
+        </plugin>
+        <plugin filename="gz-sim-contact-system" name="gz::sim::systems::Contact" />
+        <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system" />
+
+        <light name='sun' type='directional'>
+            <pose>0 0 10 0 0 0</pose>
+            <cast_shadows>true</cast_shadows>
+            <intensity>1</intensity>
+            <direction>-0.5 0.1 -0.9</direction>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.2 0.2 0.2 1</specular>
+            <attenuation>
+                <range>1000</range>
+                <linear>0.01</linear>
+                <constant>0.9</constant>
+                <quadratic>0.001</quadratic>
+            </attenuation>
+            <spot>
+                <inner_angle>0</inner_angle>
+                <outer_angle>0</outer_angle>
+                <falloff>0</falloff>
+            </spot>
+        </light>
+        
+        <model name='ground_plane'>
+        <static>true</static>
+        <link name='link'>
+            <collision name='collision'>
+            <geometry>
+                <plane>
+                <normal>0 0 1</normal>
+                <size>100 100</size>
+                </plane>
+            </geometry>
+            <surface>
+                <friction>
+                <ode/>
+                </friction>
+                <bounce/>
+                <contact/>
+            </surface>
+            </collision>
+            <visual name='visual'>
+            <geometry>
+                <plane>
+                <normal>0 0 1</normal>
+                <size>100 100</size>
+                </plane>
+            </geometry>
+            <material>
+                <ambient>0.8 0.8 0.8 1</ambient>
+                <diffuse>0.8 0.8 0.8 1</diffuse>
+                <specular>0.8 0.8 0.8 1</specular>
+            </material>
+            </visual>
+            <pose>0 0 0 0 0 0</pose>
+            <inertial>
+            <pose>0 0 0 0 0 0</pose>
+            <mass>1</mass>
+            <inertia>
+                <ixx>1</ixx>
+                <ixy>0</ixy>
+                <ixz>0</ixz>
+                <iyy>1</iyy>
+                <iyz>0</iyz>
+                <izz>1</izz>
+            </inertia>
+            </inertial>
+            <enable_wind>false</enable_wind>
+        </link>
+        <pose>0 0 0 0 0 0</pose>
+        <self_collide>false</self_collide>
+        </model>
+    </world>
+</sdf>

--- a/software/ros_ws/src/perseus_simulation/worlds/perseus_world.sdf
+++ b/software/ros_ws/src/perseus_simulation/worlds/perseus_world.sdf
@@ -6,22 +6,14 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
 
-        <plugin filename="libgz-sim-physics-system"
-            name="gz::sim::systems::Physics">
-        </plugin>
-        <plugin filename="libgz-sim-user-commands-system"
-            name="gz::sim::systems::UserCommands">
-        </plugin>
-        <plugin filename="libgz-sim-scene-broadcaster-system"
-            name="gz::sim::systems::SceneBroadcaster">
-        </plugin>
-        <plugin filename="gz-sim-sensors-system"
-            name="gz::sim::systems::Sensors">
+        <plugin filename="libgz-sim-physics-system" name="gz::sim::systems::Physics" />
+        <plugin filename="libgz-sim-user-commands-system" name="gz::sim::systems::UserCommands" />
+        <plugin filename="libgz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster" />
+        <plugin filename="gz-sim-sensors-system" name="gz::sim::systems::Sensors">
             <render_engine>ogre2</render_engine>
         </plugin>
-        <plugin filename="gz-sim-contact-system"
-            name="gz::sim::systems::Contact">
-        </plugin>
+        <plugin filename="gz-sim-contact-system" name="gz::sim::systems::Contact" />
+        <plugin name="gz::sim::systems::Imu" filename="gz-sim-imu-system" />
 
         <light type="directional" name="sun">
             <cast_shadows>true</cast_shadows>


### PR DESCRIPTION
Added a LIDAR on top of the Perseus model in Gazebo, in addition to an IMU (bridged to `/scan` and `/imu` respectively). Fixed some bugs I encountered along the way, including a proper fix for the wheel friction coefficients, allowing it to turn. Also added the empty world back in for easier testing.