### PR TITLE
Fixed RGB ordering

### DIFF
--- a/firmware/light-tower/src/main.cpp
+++ b/firmware/light-tower/src/main.cpp
@@ -7,7 +7,7 @@ CRGB leds[NUM_LEDS];
 
 void setup()
 {
-    FastLED.addLeds<WS2811, DATA_PIN, BRG>(leds, NUM_LEDS);  // BRG is the order of this specific strip, usually they are RGB.
+    FastLED.addLeds<WS2811, DATA_PIN, GRB>(leds, NUM_LEDS);  // BRG is the order of this specific strip, usually they are RGB.
 }
 
 void loop()
@@ -15,12 +15,12 @@ void loop()
     // Turn the LED on, then pause
     for (int i = 0; i <= 32; i++)
     {  // each band contains 8 segments of LEDs, 0 is first, 44 is last (top).
-        leds[i] = CRGB(255, 255, 255);
+        leds[i] = CRGB(0, 255, 0);
     }
     for (int i = 32; i <= 44; i++)
     {
         leds[i] = CRGB(255, 255, 255);
     }
     FastLED.show();
-    delay(100);
+    delay(500);
 }


### PR DESCRIPTION
The light was supposedly BRG but it appears that wasn't the case, GBR is the correct format.