### PR TITLE
Bugfix - perseus_sensors (m2m2_lidar): bug fix that the version appended

### DIFF
--- a/software/ros_ws/src/perseus_sensors/CMakeLists.txt
+++ b/software/ros_ws/src/perseus_sensors/CMakeLists.txt
@@ -83,8 +83,6 @@ target_link_libraries(m2m2_lidar PUBLIC simple_networking OpenSSL::Crypto)
 # Install ROS Executable
 install(TARGETS m2m2_lidar DESTINATION lib/${PROJECT_NAME})
 
-# Versioning
-set_target_properties(m2m2_lidar PROPERTIES VERSION ${PROJECT_VERSION})
 # ROS LIBRARY POST-INSTALL
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 


### PR DESCRIPTION
- Cmake was being asked to append the version number to the node name.

This branch ought to have been a bugfix in hindsight.