### PR TITLE
Fix Perseus launch in Nix production environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -319,7 +319,6 @@ CATKIN_IGNORE
 !.vscode/extensions.json
 !.vscode/*.code-snippets
 !.vscode/c_cpp_properties.json
-firmware/light-tower/.vscode/extensions.json
 
 # Local History for Visual Studio Code
 .history/

--- a/firmware/light-tower/.gitignore
+++ b/firmware/light-tower/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+.vscode/extensions.json

--- a/firmware/light-tower/.vscode/extensions.json
+++ b/firmware/light-tower/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  // See http://go.microsoft.com/fwlink/?LinkId=827846
-  // for the documentation about the extensions.json format
-  "recommendations": ["platformio.platformio-ide"],
-  "unwantedRecommendations": ["ms-vscode.cpptools-extension-pack"]
-}

--- a/software/ros_ws/src/perseus_description/ros2_control/perseus.ros2_control.xacro
+++ b/software/ros_ws/src/perseus_description/ros2_control/perseus.ros2_control.xacro
@@ -25,16 +25,19 @@
       <xacro:ros2_control_joint name="rear_right" id="3"/>
     </ros2_control>
 
-    <gazebo>
-      <plugin filename="libgz_ros2_control-system.so"
-        name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-        <ros>
-          <namespace>${namespace}</namespace>
-          <!-- <remapping>/diff_drive_base_controller/cmd_vel:=/cmd_vel</remapping> -->
-        </ros>
-        <parameters>$(find perseus)/config/perseus_controllers.yaml</parameters>
-        <parameters>$(find perseus_simulation)/config/ros2_control_sim.yaml</parameters>
-      </plugin>
-    </gazebo>
+    <xacro:property name="is_sim" value='${hardware_plugin == "gz_ros2_control/GazeboSimSystem"}' />
+    <xacro:if value="${is_sim}">
+      <gazebo>
+        <plugin filename="libgz_ros2_control-system.so"
+          name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+          <ros>
+            <namespace>${namespace}</namespace>
+            <!-- <remapping>/diff_drive_base_controller/cmd_vel:=/cmd_vel</remapping> -->
+          </ros>
+          <parameters>$(find perseus)/config/perseus_controllers.yaml</parameters>
+          <parameters>$(find perseus_simulation)/config/ros2_control_sim.yaml</parameters>
+        </plugin>
+      </gazebo>
+    </xacro:if>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
The ros2 control URDF description was trying to pull in files from `perseus_simulation` (which is not available in the standard production environment). This disables that.