### PR TITLE
fix: Use correct axes for xbox deadman switch(es)

### DIFF
--- a/software/ros_ws/src/input_devices/input_devices/xbox_controller.py
+++ b/software/ros_ws/src/input_devices/input_devices/xbox_controller.py
@@ -42,8 +42,8 @@ class XboxController(Node):
         # Xbox controller axis mappings
         self.LEFT_STICK_Y_AXIS = 1
         self.RIGHT_STICK_X_AXIS = 2
-        self.RIGHT_TRIGGER_AXIS = 5  # Regular speed deadman switch
-        self.LEFT_TRIGGER_AXIS = 6  # High speed deadman switch
+        self.RIGHT_TRIGGER_AXIS = 4  # Regular speed deadman switch
+        self.LEFT_TRIGGER_AXIS = 5  # High speed deadman switch
 
         # Create range constraints as instance variables for use in callback
         self._speed_range = FloatingPointRange(from_value=0.0, to_value=10.0, step=0.01)


### PR DESCRIPTION
Needed to be axes 4 and 5, not 5 and 6. Now turbo mode works properly