### PR TITLE
Fix: Nix setup script updated for new Determinate Nix installer

### DIFF
--- a/software/scripts/nix-setup.sh
+++ b/software/scripts/nix-setup.sh
@@ -25,32 +25,37 @@ else
   echo "Nix already present on system!"
 fi
 
+NIX_CONFIG_FILE_PATH="/etc/nix/nix.conf"
+DET_NIX_CONFIG_FILE_PATH="/etc/nix/nix.custom.conf"
+if test -f "$DET_NIX_CONFIG_FILE_PATH"; then
+    NIX_CONFIG_FILE_PATH="$DET_NIX_CONFIG_FILE_PATH"
+fi
 # Add the ROS overlay binary cache + our own cache to the trusted substituters and keys.
 # Allows us to use them in the flake.
 EXTRA_TRUSTED_SUBSTITUTERS="extra-trusted-substituters = https://roar-qutrc.cachix.org https://ros.cachix.org"
-if grep -Fq "$EXTRA_TRUSTED_SUBSTITUTERS" /etc/nix/nix.conf; then
+if grep -Fq "$EXTRA_TRUSTED_SUBSTITUTERS" "$NIX_CONFIG_FILE_PATH"; then
   echo "Extra trusted substituters already present!"
 else
   echo "Adding extra trusted substituters..."
-  echo "$EXTRA_TRUSTED_SUBSTITUTERS" | sudo tee -a /etc/nix/nix.conf
+  echo "$EXTRA_TRUSTED_SUBSTITUTERS" | sudo tee -a "$NIX_CONFIG_FILE_PATH"
   RESTART_NIX_DAEMON=true
 fi
 
 EXTRA_TRUSTED_KEYS="extra-trusted-public-keys = roar-qutrc.cachix.org-1:ZKgHZSSHH2hOAN7+83gv1gkraXze5LSEzdocPAEBNnA= ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo="
-if grep -Fq "$EXTRA_TRUSTED_KEYS" /etc/nix/nix.conf; then
+if grep -Fq "$EXTRA_TRUSTED_KEYS" "$NIX_CONFIG_FILE_PATH"; then
   echo "Extra trusted keys already present!"
 else
   echo "Adding extra trusted keys..."
-  echo "$EXTRA_TRUSTED_KEYS" | sudo tee -a /etc/nix/nix.conf
+  echo "$EXTRA_TRUSTED_KEYS" | sudo tee -a "$NIX_CONFIG_FILE_PATH"
   RESTART_NIX_DAEMON=true
 fi
 
 DISABLE_WARN_DIRTY="warn-dirty = false"
-if grep -Fq "$DISABLE_WARN_DIRTY" /etc/nix/nix.conf; then
+if grep -Fq "$DISABLE_WARN_DIRTY" "$NIX_CONFIG_FILE_PATH"; then
   echo "Dirty git tree warning already disabled!"
 else
   echo "Disabling dirty git tree warning..."
-  echo "$DISABLE_WARN_DIRTY" | sudo tee -a /etc/nix/nix.conf
+  echo "$DISABLE_WARN_DIRTY" | sudo tee -a "$NIX_CONFIG_FILE_PATH"
   RESTART_NIX_DAEMON=true
 fi
 

--- a/software/scripts/nix-setup.sh
+++ b/software/scripts/nix-setup.sh
@@ -28,7 +28,7 @@ fi
 NIX_CONFIG_FILE_PATH="/etc/nix/nix.conf"
 DET_NIX_CONFIG_FILE_PATH="/etc/nix/nix.custom.conf"
 if test -f "$DET_NIX_CONFIG_FILE_PATH"; then
-    NIX_CONFIG_FILE_PATH="$DET_NIX_CONFIG_FILE_PATH"
+  NIX_CONFIG_FILE_PATH="$DET_NIX_CONFIG_FILE_PATH"
 fi
 # Add the ROS overlay binary cache + our own cache to the trusted substituters and keys.
 # Allows us to use them in the flake.


### PR DESCRIPTION
Requires writing to a different file for Nix configuration. Should probably recommend un- and then re-installing Nix to get the latest behaviour, since it comes with better defaults.