### PR TITLE
fix: Pass `--accept-flake-config` into `use flake`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,7 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w=" &>/dev/null
 fi
 
-use flake
+use flake . --accept-flake-config
 # print out autocomplete instructions
 printf '\033[0;33m' # orange text (makes it stand out more)
 echo "--------------------"


### PR DESCRIPTION
Should prevent building everything locally instead of downloading issues. Hopefully. Will also require people to run `direnv allow` again unfortunately. @DingoOz this is that error you were running into.