### PR TITLE
fix: Depend on realsense2-description

### DIFF
--- a/software/ros_ws/nix-packages/perseus-sensors.nix
+++ b/software/ros_ws/nix-packages/perseus-sensors.nix
@@ -8,6 +8,7 @@
   openssl,
   rclcpp,
   realsense2-camera,
+  realsense2-description,
   sensor-msgs,
   simple-networking,
 }:
@@ -25,6 +26,7 @@ buildRosPackage rec {
     openssl
     rclcpp
     realsense2-camera
+    realsense2-description
     sensor-msgs
     simple-networking
   ];

--- a/software/ros_ws/src/perseus_sensors/package.xml
+++ b/software/ros_ws/src/perseus_sensors/package.xml
@@ -16,6 +16,7 @@
   <depend>openssl</depend>
   <depend>nlohmann-json-dev</depend>
   <exec_depend>realsense2-camera</exec_depend>
+  <exec_depend>realsense2-description</exec_depend>
   
 
   <export>


### PR DESCRIPTION
Was missing. Needed for some use cases.