### PR TITLE
Add twist_mux node

### DIFF
--- a/software/ros_ws/nix-packages/perseus.nix
+++ b/software/ros_ws/nix-packages/perseus.nix
@@ -12,6 +12,7 @@
   ros2controlcli,
   ros2launch,
   rviz2,
+  twist-mux,
   xacro,
 }:
 buildRosPackage rec {
@@ -32,6 +33,7 @@ buildRosPackage rec {
     ros2controlcli
     ros2launch
     rviz2
+    twist-mux
     xacro
   ];
   nativeBuildInputs = [ ament-cmake ];

--- a/software/ros_ws/src/input_devices/launch/xbox_controller.launch.py
+++ b/software/ros_ws/src/input_devices/launch/xbox_controller.launch.py
@@ -52,7 +52,7 @@ def generate_launch_description():
                 "high_high_speed_multiplier": high_speed_multiplier,
             }
         ],
-        remappings=[("/input_devices/cmd_vel", "/cmd_vel")],
+        remappings=[("/input_devices/cmd_vel", "/joy_vel")],
     )
     nodes = [joy_node, controller_node]
 

--- a/software/ros_ws/src/perseus/config/perseus_controllers.yaml
+++ b/software/ros_ws/src/perseus/config/perseus_controllers.yaml
@@ -27,7 +27,7 @@ diff_drive_base_controller:
     odom_frame_id: odom
     base_frame_id: base_link
     enable_odom_tf: true
-    cmd_vel_timeout: 0.1
+    cmd_vel_timeout: 1.0
     #publish_limited_velocity: true
     #use_stamped_vel: false
 

--- a/software/ros_ws/src/perseus/config/twist_mux.yaml
+++ b/software/ros_ws/src/perseus/config/twist_mux.yaml
@@ -1,0 +1,16 @@
+twist_mux:
+  ros__parameters:
+    use_stamped: true
+    topics:
+      navigation:
+        topic: cmd_vel
+        timeout: 0.5
+        priority: 10
+      joystick:
+        topic: joy_vel
+        timeout: 0.5
+        priority: 100
+      keyboard:
+        topic: key_vel
+        timeout: 0.5
+        priority: 90

--- a/software/ros_ws/src/perseus/launch/controllers.launch.py
+++ b/software/ros_ws/src/perseus/launch/controllers.launch.py
@@ -50,7 +50,7 @@ def generate_launch_description():
         arguments=[
             "diff_drive_base_controller",
             "--controller-ros-args",
-            "--remap /diff_drive_base_controller/cmd_vel:=/cmd_vel",
+            "--remap /diff_drive_base_controller/cmd_vel:=/cmd_vel_out",
         ],
         parameters=[use_sim_time_param],
     )

--- a/software/ros_ws/src/perseus/launch/perseus.launch.py
+++ b/software/ros_ws/src/perseus/launch/perseus.launch.py
@@ -97,6 +97,22 @@ def generate_launch_description():
             "use_sim_time": use_sim_time,
         }.items(),
     )
+    twist_mux_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("perseus"),
+                        "launch",
+                        "twist_mux.launch.py",
+                    ]
+                )
+            ]
+        ),
+        launch_arguments={
+            "use_sim_time": use_sim_time,
+        }.items(),
+    )
     rosbridge_launch = IncludeLaunchDescription(
         AnyLaunchDescriptionSource(
             [
@@ -116,6 +132,7 @@ def generate_launch_description():
     launch_files = [
         OpaqueFunction(function=robot_state_publisher),
         controllers_launch,
+        twist_mux_launch,
         rosbridge_launch,
     ]
 

--- a/software/ros_ws/src/perseus/launch/twist_mux.launch.py
+++ b/software/ros_ws/src/perseus/launch/twist_mux.launch.py
@@ -1,0 +1,36 @@
+from launch import LaunchDescription
+
+from launch.substitutions import (
+    PathJoinSubstitution,
+    LaunchConfiguration,
+)
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    # ARGUMENTS
+    use_sim_time = LaunchConfiguration("use_sim_time", default=False)
+    use_sim_time_param = {"use_sim_time": use_sim_time}
+
+    arguments = []
+
+    # CONFIG + DATA FILES
+    mux_config = PathJoinSubstitution(
+        [FindPackageShare("perseus"), "config", "twist_mux.yaml"]
+    )
+
+    # NODES
+    twist_mux = Node(
+        package="twist_mux",
+        executable="twist_mux",
+        output="screen",
+        parameters=[use_sim_time_param, mux_config],
+    )
+
+    nodes = [
+        twist_mux,
+    ]
+
+    return LaunchDescription(arguments + nodes)

--- a/software/ros_ws/src/perseus/package.xml
+++ b/software/ros_ws/src/perseus/package.xml
@@ -12,6 +12,7 @@
 
   <!-- base -->
   <exec_depend>perseus_hardware</exec_depend>
+  <exec_depend>twist_mux</exec_depend>
 
   <!-- ros2 control -->
   <exec_depend>controller_manager</exec_depend>


### PR DESCRIPTION
Twist mux takes in, in order of increasing priority:
- cmd_vel
- key_vel
- joy_vel
And outputs the highest-priority option to cmd_vel_out

Also increased the diff drive controller timeout to allow for clock desync tolerance.