### PR TITLE
docs: Update the perseus simulation tutorial

### DIFF
--- a/docs/source/tutorials/running-simulation.md
+++ b/docs/source/tutorials/running-simulation.md
@@ -79,18 +79,23 @@ ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -r /cmd_vel:=/cm
 If the rover doesn't respond to keyboard commands:
 
 1. **Check if the controller is active**:
+
    ```bash
    ros2 control list_controllers
    ```
+
    You should see `diff_drive_base_controller` as `active`. If it shows `inactive`, run:
+
    ```bash
    ros2 control set_controller_state diff_drive_base_controller active
    ```
 
 2. **Verify topic connections**:
+
    ```bash
    ros2 topic info /cmd_vel_out
    ```
+
    This should show both publishers and subscribers.
 
 3. **Test topic communication**:

--- a/docs/source/tutorials/running-simulation.md
+++ b/docs/source/tutorials/running-simulation.md
@@ -48,21 +48,62 @@ ros2 launch perseus_simulation perseus_sim.launch.py
 
 This command launches the Gazebo simulation with the Perseus rover model.
 
-## Controlling the Rover
+### 6. Activate the Drive Controller
 
-Once the simulation is running, you can control the rover using keyboard input. In a **separate terminal**, run:
+After the simulation has fully started, you need to activate the drive controller. In a **separate terminal**, run:
 
 ```bash
 nix develop .#simulation
 cd software/ros_ws
 source install/setup.bash
-ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -p stamped:=true
+ros2 control set_controller_state diff_drive_base_controller active
 ```
+
+This step is required to enable the rover's wheel movement in simulation.
+
+## Controlling the Rover
+
+Once the simulation is running and the controller is active, you can control the rover using keyboard input. In a **separate terminal**, run:
+
+```bash
+nix develop .#simulation
+cd software/ros_ws
+source install/setup.bash
+ros2 run teleop_twist_keyboard teleop_twist_keyboard --ros-args -r /cmd_vel:=/cmd_vel_out
+```
+
+## Troubleshooting
+
+### Rover Not Moving in Teleop
+
+If the rover doesn't respond to keyboard commands:
+
+1. **Check if the controller is active**:
+   ```bash
+   ros2 control list_controllers
+   ```
+   You should see `diff_drive_base_controller` as `active`. If it shows `inactive`, run:
+   ```bash
+   ros2 control set_controller_state diff_drive_base_controller active
+   ```
+
+2. **Verify topic connections**:
+   ```bash
+   ros2 topic info /cmd_vel_out
+   ```
+   This should show both publishers and subscribers.
+
+3. **Test topic communication**:
+   ```bash
+   ros2 topic echo /cmd_vel_out
+   ```
+   You should see messages when pressing keys in the teleop terminal.
 
 :::
 
 - The first time you run the simulation, Gazebo may download the lunar landscape model, which can take up to 20 minutes
 - Ensure you have an internet connection for the initial setup
 - The simulation requires significant system resources and may perform better with hardware acceleration
+- If the rover doesn't move, make sure the drive controller is activated (step 6)
 
 :::


### PR DESCRIPTION
- added a section on how to manage the controller lifecycle

Tested the documentation with local host: 
<img width="2862" height="1990" alt="image" src="https://github.com/user-attachments/assets/3b759cb2-1658-47f9-9f1b-ac881727e446" />
