### PR TITLE
fix: Exclude meshes from formatting

### DIFF
--- a/treefmt.nix
+++ b/treefmt.nix
@@ -61,6 +61,12 @@
         "*.ico"
         "*.pdf"
         "*sdkconfig*"
+        # meshes
+        "software/ros_ws/src/**/meshes/**"
+        "*.dae"
+        "*.stl"
+        "*.step"
+        "*.3mf"
         # PCBs (KiCAD)
         "hardware/**"
       ];

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -134,6 +134,11 @@ excludes = [
     "*.ico",
     "*.pdf",
     "*sdkconfig*",
+    "software/ros_ws/src/**/meshes/**",
+    "*.dae",
+    "*.stl",
+    "*.step",
+    "*.3mf",
     "hardware/**",
 ]
 on-unmatched = "warn"


### PR DESCRIPTION
Exactly what it says on the tin. Should fix formatting issues for #253 and the like.