### PR TITLE
Increased TX Queue Length attribute of can network

### DIFF
--- a/software/scripts/machine-setup.sh
+++ b/software/scripts/machine-setup.sh
@@ -82,4 +82,19 @@ echo "Enabling systemd-networkd..."
 sudo systemctl enable systemd-networkd
 echo "Restarting systemd-networkd..."
 sudo systemctl restart systemd-networkd
+
+TXQUEUELEN_RULE='SUBSYSTEM=="net", ACTION=="add|change", KERNEL=="can*", ATTR{tx_queue_len}="128"'
+TXQUEUELEN_FILENAME="/etc/udev/rules.d/80-can-txqueuelen.rules"
+if grep -Fq "$TXQUEUELEN_RULE" "$TXQUEUELEN_FILENAME" &>/dev/null; then
+  echo "TX queue length rule was already set"
+else
+  sudo touch "$TXQUEUELEN_FILENAME"
+  echo "$TXQUEUELEN_RULE" | sudo tee -a "$TXQUEUELEN_FILENAME" &>/dev/null
+  echo "TX queue length rule set up"
+fi
+
+echo "Reloading udev rules..."
+sudo udevadm control --reload-rules
+echo "Triggering setup for already connected devices..."
+sudo udevadm trigger
 echo "Done!"


### PR DESCRIPTION
Added a section to machine-setup.sh that creates a udev rules file to set the CAN network's txqueuelen attribute. I've tested it on the big-brain and it works as expected. Also added section to reload the udev rules so the change immediately takes effect.