### PR TITLE
Made URDF REP-103/REP-105 aligned,ready for Nav2 integration

### DIFF
--- a/software/ros_ws/src/input_devices/input_devices/xbox_controller.py
+++ b/software/ros_ws/src/input_devices/input_devices/xbox_controller.py
@@ -213,20 +213,19 @@ class XboxController(Node):
 
         if is_regular_speed or is_high_speed:
             # Calculate base movement
-            linear_input = joy_msg.axes[self.LEFT_STICK_Y_AXIS]
-            rotation_input = joy_msg.axes[self.RIGHT_STICK_X_AXIS]
+            # Negate Y-axis: joystick forward (away from user) gives negative values,
+            # but ROS convention is positive linear.x = forward
+            linear_input = -joy_msg.axes[self.LEFT_STICK_Y_AXIS]
+            # Negate X-axis: joystick right gives positive values,
+            # but ROS convention is positive angular.z = turn left
+            rotation_input = -joy_msg.axes[self.RIGHT_STICK_X_AXIS]
 
             # Apply appropriate scaling based on which deadman switch is engaged
             speed_multiplier = self.high_speed_multiplier if is_high_speed else 1.0
 
             twist.linear.x = linear_input * self.translation_scale * speed_multiplier
 
-            rotation_value = rotation_input * self.rotation_scale * speed_multiplier
-
-            # Invert rotation direction when moving backwards
-            twist.angular.z = (
-                -1.0 * rotation_value if twist.linear.x < 0 else rotation_value
-            )
+            twist.angular.z = rotation_input * self.rotation_scale * speed_multiplier
 
         # Create and publish appropriate message type
         if self.use_stamped_msg:

--- a/software/ros_ws/src/perseus_description/urdf/inertia_macros.xacro
+++ b/software/ros_ws/src/perseus_description/urdf/inertia_macros.xacro
@@ -10,12 +10,21 @@
       ixy="0" iyz="0" ixz="0"/>
   </xacro:macro>
 
-  <!-- Cylinder inertia macro -->
+  <!-- Cylinder inertia macro (axis along Z) -->
   <xacro:macro name="cylinder_inertia" params="m radius length">
-    <inertia 
-      ixx="${m*(3*radius*radius+length*length)/12}" 
-      iyy="${m*(3*radius*radius+length*length)/12}" 
+    <inertia
+      ixx="${m*(3*radius*radius+length*length)/12}"
+      iyy="${m*(3*radius*radius+length*length)/12}"
       izz="${m*radius*radius/2}"
+      ixy="0" iyz="0" ixz="0"/>
+  </xacro:macro>
+
+  <!-- Cylinder inertia macro (axis along Y) - use for wheels -->
+  <xacro:macro name="cylinder_inertia_y" params="m radius length">
+    <inertia
+      ixx="${m*(3*radius*radius+length*length)/12}"
+      iyy="${m*radius*radius/2}"
+      izz="${m*(3*radius*radius+length*length)/12}"
       ixy="0" iyz="0" ixz="0"/>
   </xacro:macro>
 

--- a/software/ros_ws/src/perseus_description/urdf/wheel.urdf.xacro
+++ b/software/ros_ws/src/perseus_description/urdf/wheel.urdf.xacro
@@ -4,33 +4,26 @@
 <xacro:macro name="wheel" params="prefix:=^ side:=^ end:=^">
   <link name="${prefix}${end}_${side}_wheel">
     <inertial>
-      <xacro:if value="${side == 'left'}">
-        <origin xyz="0.0 0.0  0.0" rpy="0.0 0.0 ${pi}"/>
-      </xacro:if>
-      <xacro:if value="${side == 'right'}">
-        <origin xyz="0.0 0.0  0.0" rpy="0.0 0.0 -${pi}"/>
-      </xacro:if>
-      <mass value="${wheel_mass}"/>        
-      <xacro:cylinder_inertia m="${wheel_mass}" radius="${wheel_radius}" length="${wheel_length}"/>
+      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+      <mass value="${wheel_mass}"/>
+      <!-- Use Y-axis aligned cylinder inertia since wheels rotate around Y axis -->
+      <xacro:cylinder_inertia_y m="${wheel_mass}" radius="${wheel_radius}" length="${wheel_length}"/>
     </inertial>
     <visual>
+      <!-- Rotate mesh so tread pattern faces outward -->
       <xacro:if value="${side == 'left'}">
-        <origin xyz="0.0 0.0  0.0" rpy="0.0 0.0 ${pi}"/>
+        <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 ${pi}"/>
       </xacro:if>
       <xacro:if value="${side == 'right'}">
-        <origin xyz="0.0 0.0  0.0" rpy="0.0 0.0 -${pi}"/>
+        <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
       </xacro:if>
       <geometry>
-        <mesh scale="0.1 0.1  0.1" filename="file://$(find perseus_description)/meshes/wheel.dae"/>
+        <mesh scale="0.1 0.1 0.1" filename="file://$(find perseus_description)/meshes/wheel.dae"/>
       </geometry>
     </visual>
     <collision>
-      <xacro:if value="${side == 'left'}">
-        <origin xyz="0.0 0.0 0.0" rpy="${pi/2} 0.0 ${pi}"/>
-      </xacro:if>
-        <xacro:if value="${side == 'right'}">
-      <origin xyz="0.0 0.0 0.0" rpy="${pi/2} 0.0 -${pi}"/>
-      </xacro:if>
+      <!-- Rotate cylinder 90° around X to align with Y axis (wheel axle) -->
+      <origin xyz="0.0 0.0 0.0" rpy="${pi/2} 0.0 0.0"/>
       <geometry>
         <cylinder radius="${wheel_radius}" length="${wheel_length}"/>
       </geometry>
@@ -38,17 +31,17 @@
   </link>
 
   <joint name="${prefix}${end}_${side}_wheel_joint" type="continuous">
-    <xacro:if value="${side == 'left'}">
-      <origin xyz="0 ${wheels_y_offset} 0.0" rpy="0.0 0.0 0"/>
-      <axis xyz="0 1 0" rpy="0 0 0"/>
-    </xacro:if>
-    <xacro:if value="${side == 'right'}">
-      <origin xyz="0 ${-wheels_y_offset} 0.0" rpy="0.0 0.0 ${pi}"/>
-      <axis xyz="0 -1 0" rpy="0 0 0"/>
-    </xacro:if>
-    <dynamics damping="0.2" friction="0.3"/>
     <parent link="${prefix}${end}_${side}_motor"/>
     <child link="${prefix}${end}_${side}_wheel"/>
+    <xacro:if value="${side == 'left'}">
+      <origin xyz="0.0 ${wheels_y_offset} 0.0" rpy="0.0 0.0 0.0"/>
+    </xacro:if>
+    <xacro:if value="${side == 'right'}">
+      <origin xyz="0.0 ${-wheels_y_offset} 0.0" rpy="0.0 0.0 0.0"/>
+    </xacro:if>
+    <!-- Axis -Y: positive velocity = forward motion (standard ROS/diff_drive convention) -->
+    <axis xyz="0 -1 0"/>
+    <dynamics damping="0.2" friction="0.3"/>
   </joint>
 
 
@@ -62,17 +55,16 @@
           <friction>
               <ode>
                   <!--
-                  In this case, the wheels need lower sideways than forwards coefficients of friction
-                  so that the rover can turn (skid steer) -->
-                  <!-- forward coefficient of friction -->
-                  <mu>100</mu>
-                  <!-- perpendicular coefficient of friction -->
-                  <mu2>1</mu2>
-                  <!--
-                  However, since mu/mu2 are normally relative to world coordinates,
-                  the rover would only be able to turn 90 degrees either way before they swapped, making turning impossible.
-                  To solve this, we need to specify the direction that mu/mu2 are relative to.
+                  Skid-steer friction setup:
+                  - mu: friction in fdir1 direction (forward/backward rolling)
+                  - mu2: friction perpendicular to fdir1 (sideways sliding for turning)
+                  - fdir1: primary friction direction in link frame
                   -->
+                  <!-- Forward/backward friction - high to grip and drive -->
+                  <mu>1.5</mu>
+                  <!-- Sideways friction - low to allow skid steering -->
+                  <mu2>0.2</mu2>
+                  <!-- fdir1 points forward (X) in link frame -->
                   <fdir1>1 0 0</fdir1>
               </ode>
           </friction>

--- a/software/ros_ws/src/perseus_input_config/config/8bitdo_controller.yaml
+++ b/software/ros_ws/src/perseus_input_config/config/8bitdo_controller.yaml
@@ -6,7 +6,9 @@ generic_controller:
       forward:
         turbo: 2.5
         axis: 1
-        scaling: 0.7
+        # Negative scaling: joystick forward gives negative values,
+        # but ROS convention is positive linear.x = forward
+        scaling: -0.7
         enable:
           axis: 4
           is_less_than: true
@@ -18,7 +20,9 @@ generic_controller:
       turn:
         turbo: 2.5
         axis: 0
-        scaling: 1.0
+        # Negative scaling: joystick right gives positive values,
+        # but ROS convention is positive angular.z = turn left
+        scaling: -1.0
         enable:
           follows: drive.forward.enable
         turbo_enable:

--- a/software/ros_ws/src/perseus_input_config/config/logitech_controller.yaml
+++ b/software/ros_ws/src/perseus_input_config/config/logitech_controller.yaml
@@ -6,7 +6,9 @@ generic_controller:
       forward:
         turbo: 2.5
         axis: 1
-        scaling: 0.7
+        # Negative scaling: joystick forward gives negative values,
+        # but ROS convention is positive linear.x = forward
+        scaling: -0.7
         enable:
           axis: 2
           is_less_than: true
@@ -18,7 +20,9 @@ generic_controller:
       turn:
         turbo: 2.5
         axis: 0
-        scaling: 1.0
+        # Negative scaling: joystick right gives positive values,
+        # but ROS convention is positive angular.z = turn left
+        scaling: -1.0
         enable:
           follows: drive.forward.enable
         turbo_enable:

--- a/software/ros_ws/src/perseus_input_config/config/xbox_controller_wired.yaml
+++ b/software/ros_ws/src/perseus_input_config/config/xbox_controller_wired.yaml
@@ -6,7 +6,9 @@ generic_controller:
       forward:
         turbo: 2.5
         axis: 1
-        scaling: 0.7
+        # Negative scaling: joystick forward (away from user) gives negative values,
+        # but ROS convention is positive linear.x = forward
+        scaling: -0.7
         enable:
           axis: 2
           is_less_than: true
@@ -18,7 +20,9 @@ generic_controller:
       turn:
         turbo: 2.5
         axis: 0
-        scaling: 0.5
+        # Negative scaling: joystick right gives positive values,
+        # but ROS convention is positive angular.z = turn left
+        scaling: -0.5
         enable:
           follows: drive.forward.enable
         turbo_enable:

--- a/software/ros_ws/src/perseus_input_config/config/xbox_controller_wireless.yaml
+++ b/software/ros_ws/src/perseus_input_config/config/xbox_controller_wireless.yaml
@@ -6,7 +6,9 @@ generic_controller:
       forward:
         turbo: 2.5
         axis: 1
-        scaling: 0.7
+        # Negative scaling: joystick forward gives negative values,
+        # but ROS convention is positive linear.x = forward
+        scaling: -0.7
         enable:
           axis: 5
           is_less_than: true
@@ -18,7 +20,9 @@ generic_controller:
       turn:
         turbo: 2.5
         axis: 0
-        scaling: 0.5
+        # Negative scaling: joystick right gives positive values,
+        # but ROS convention is positive angular.z = turn left
+        scaling: -0.5
         enable:
           follows: drive.forward.enable
         turbo_enable:


### PR DESCRIPTION
- wheel.urdf.xacro - Unified wheel axis to -Y for REP-103 compliance (positive velocity = forward)
- inertia_macros.xacro - Added cylinder_inertia_y macro for Y-axis aligned cylinders
- wheel.urdf.xacro - using cylinder inertia, and friction tuned [mu=1.5, mu2=0.2]
- xbox_controller.py - Negated joystick axes for ROS convention, removed conditional rotation inversion
- All controller YAMLs - Negative scaling for forward/turn to match ROS convention