### PR TITLE
docs: Updated references to 'architecture' to refer to 'systems'

### DIFF
--- a/docs/source/home/getting-started.md
+++ b/docs/source/home/getting-started.md
@@ -111,7 +111,7 @@ To the experienced ROS2 developers - you may notice the lack of a `--symlink-ins
 ### Before you start
 
 However, before you start writing code, there's a few things you need to read through first.
-The most important one is the software [architecture](project:/architecture/software.md), which goes over how all the software links together and how it's laid out.
+The most important one is the software [systems](project:/systems/software-index.md), which goes over how all the software links together and how it's laid out.
 The other document is the software [standards](project:/standards/software-index.md), which details the standards to which your software is expected to be written.
 If your software _doesn't_ meet these standards, we unfortunately won't be able to merge your changes until you fix the issues - if code standards aren't enforced, the code **will** quickly become an un-maintainable mess, leading to another rewrite.
 

--- a/docs/source/home/nix-basics.md
+++ b/docs/source/home/nix-basics.md
@@ -113,7 +113,7 @@ This is particularly useful to select the latest version from `nixpkgs-unstable`
 :::
 ::::
 
-Every [architecture](project:/architecture.md) document contains a "Nix outputs" section if applicable detailing the available outputs to use.
+Every [systems](project:/systems-index.md) document contains a "Nix outputs" section if applicable detailing the available outputs to use.
 
 :::{tip}
 You can override the default search behaviour of the commands if you wish.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -3,8 +3,8 @@
 Welcome! This is the home of the Perseus Rover documentation. It contains (well, it should, if people have been updating it) everything you need to know about building software and electronics for the rover.
 
 If you're new here, you'll probably be wanting to read through the <project:/home/getting-started.md> page, which contains everything you need to know to get yourself set up to start writing code.
-Alternatively, if you're instead arms-deep in the rover's guts and wondering where that wire goes, or you're interested in designing electronics to go on-board the rover, check out the [hardware architecture](project:/architecture/hardware.md).
-Finally, if you're wondering what a specific bit of code does, you probably want look over the [software architecture](project:/architecture/software.md), or alternatively there's the auto-generated [code documentation](project:/generated/index.rst).
+Alternatively, if you're instead arms-deep in the rover's guts and wondering where that wire goes, or you're interested in designing electronics to go on-board the rover, check out the [hardware system](project:/systems/hardware-index.md).
+Finally, if you're wondering what a specific bit of code does, you probably want look over the [software system](project:/systems/software-index.md), or alternatively there's the auto-generated [code documentation](project:/generated/index.rst).
 
 ## Conventions
 

--- a/docs/source/systems-index.md
+++ b/docs/source/systems-index.md
@@ -3,15 +3,15 @@
 This section describes what systems are present on Perseus, what they are and what they do. For information how to develop each of these systems check their corresponding pages in the <project:development-index.md> section.
 
 Fundamentally, the rover is split into two main sub-systems: Hardware, and Software.
-The [_software_ architecture](project:/architecture/software.md) lays out how the _code_ interacts with itself and its environment, as well as which bits do what.
-The [_hardware_ architecture](project:/architecture/hardware.md) goes over how everything's _physically_ connected and laid out, as well as the electrical wiring.
+The [_software_ system](project:/systems/software-index.md) lays out how the _code_ interacts with itself and its environment, as well as which bits do what.
+The [_hardware_ system](project:/systems/hardware-index.md) goes over how everything's _physically_ connected and laid out, as well as the electrical wiring.
 
 Whilst those two documents contain the majority of the information you'll need day-to-day, there are also some other moving parts to consider as well:
 
-- The [CI/CD](project:/architecture/ci-cd.md) pipeline is what runs our automated testing and handles deploying this very website
-- Speaking of this website, its build process can be a little bit convoluted, so it gets a [document](project:/architecture/documentation.md) too
-- If you're writing firmware or a hardware interface that talks on the CAN bus, you'll need to read through what we've titled the [Canifesto](project:/architecture/can-bus.md)
-- You've probably noticed by now that we use Nix to manage all our software - this gets complicated quickly and there's only so much that source comments can do, so it's explained [here](project:/architecture/nix.md)
+- The [CI/CD](project:/systems/ci-cd.md) pipeline is what runs our automated testing and handles deploying this very website
+- Speaking of this website, its build process can be a little bit convoluted, so it gets a [document](project:/systems/documentation.md) too
+- If you're writing firmware or a hardware interface that talks on the CAN bus, you'll need to read through what we've titled the [Canifesto](project:/systems/can-bus.md)
+- You've probably noticed by now that we use Nix to manage all our software - this gets complicated quickly and there's only so much that source comments can do, so it's explained [here](project:/systems/nix.md)
 
 If you're just looking for a high-level overview, this diagram contains the basics of the information flow between modules (as well as some power information):
 ![Architecture](generated/system_architecture.drawio.svg){.has-dark-opt}

--- a/docs/source/systems/ci-cd.md
+++ b/docs/source/systems/ci-cd.md
@@ -23,7 +23,7 @@ Since this project is built with Nix, all dependencies fixed and known ahead-of-
 ### Continuous Deployment
 
 Continuous Deployment is exactly what it sounds like - automatically _deploying_ a project to production after the continuous _delivery_ process of the pipeline finishes its build.
-For this project, we aren't employing continuous deployment for anything but the docs website - see the [documentation architecture](project:/architecture/documentation.md) for details on that.
+For this project, we aren't employing continuous deployment for anything but the docs website - see the [documentation system](project:/systems/documentation.md) for details on that.
 
 ## Execution
 

--- a/docs/source/systems/documentation.md
+++ b/docs/source/systems/documentation.md
@@ -98,7 +98,7 @@ Finally, the aforementioned script does one thing - it takes in a source file pa
 
 ### Deployment
 
-As detailed in the [CI/CD Architecture](project:ci-cd.md) document, this entire project uses Nix for everything - and that extends to building in the CI/CD pipeline.
+As detailed in the [CI/CD Systems](project:ci-cd.md) document, this entire project uses Nix for everything - and that extends to building in the CI/CD pipeline.
 However, that only covers the CI part of CI/CD - deployment needs its own handling.
 
 The built documentation is currently hosted using [GitHub Pages](https://pages.github.com/), and as such requires a backing repository containing the contents which is located [here](https://github.com/ROAR-QUTRC/roar-qutrc.github.io).
@@ -163,7 +163,7 @@ The equivalent _inline_ code (standard markdown image insertion, with extension 
 :::{note}
 References in Sphinx without a leading slash are relative to the current directory!
 To reference relative to the project root (in the repo, `docs/source`), you need to make it an _absolute_ path and start it with a slash.
-Not doing so makes it relative to the current directory of _this document_ (`docs/source/architecture/`).
+Not doing so makes it relative to the current directory of _this document_ (`docs/source/systems/`).
 :::
 
 #### `docs.compressed`

--- a/docs/source/systems/software/core.md
+++ b/docs/source/systems/software/core.md
@@ -63,7 +63,7 @@ Shared libraries can be made available to your ROS2 package and nodes by includi
 
 ### Hi-CAN
 
-Abbreviated from "hierarchical CAN", Hi-CAN is the library implementing the standards laid out [here](project:/architecture/can-bus.md), and is shared across ROS and native code, as well as firmware.
+Abbreviated from "hierarchical CAN", Hi-CAN is the library implementing the standards laid out [here](project:/systems/can-bus.md), and is shared across ROS and native code, as well as firmware.
 The main library contains the code defining the main interfaces with which code will interact with the library, as well as all of the devices on the bus and their parameters.
 :::{warning}
 Since this particular library is shared between both the ROS code _and_ the firmware, it needs to be written in pure C++ (no external dependencies).


### PR DESCRIPTION
There were many references to the 'Architecture' section of the docs - this should instead point to the systems section. I've updated these to refer to the correct pages.
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/a8d95ba3-6055-47b9-9210-bef1c3d47af8" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/5dd19d37-9f4d-4865-b57d-9d29f3681fdd" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/180efc26-3ad2-4121-a1ad-400fd833c66f" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/8447ab2c-c334-4903-98d9-8c2e2316cc50" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/71e7318e-90f3-495b-9ca6-56eb11a9cb4f" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/6a9dbe1b-7ee1-4b95-9513-b71aca644c7b" />
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/b9a5dc5d-3960-4349-b8aa-798ba2897dfd" />
