### PR TITLE
Feat: Updated nix-ros-overlay to add rtabmap support for AARCH64 machines

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1771881583,
-        "narHash": "sha256-vYTYv1PoGG/Q6afrKnj7fdT+h2f4b1auOdXmQZTaldU=",
+        "lastModified": 1773270149,
+        "narHash": "sha256-DpGhjF76u0TsW+ZDbupz6wZy4jeaL4+Y75UBP9mPST4=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "43de07be5ef90341c7d135884d80759fb3fa5e4c",
+        "rev": "78c70cf36d1fe5c6cdfbf7e577a34c7bec6cbcf7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Just did a flake input update (nix-ros-overlay only). I've tested on the big-brain as well as my own laptop by adding the rtabmap packages to the workspace.