### PR TITLE
chore: Changed ROS package.xml TODO licenses to MIT

### DIFF
--- a/software/ros_ws/nix-packages/perseus-autonomy-bridge.nix
+++ b/software/ros_ws/nix-packages/perseus-autonomy-bridge.nix
@@ -34,6 +34,6 @@ buildRosPackage rec {
 
   meta = {
     description = "Autonomy Widget Bridge";
-    license = with lib.licenses; [ "TODO-License-declaration" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/software/ros_ws/nix-packages/perseus-interfaces.nix
+++ b/software/ros_ws/nix-packages/perseus-interfaces.nix
@@ -41,6 +41,6 @@ buildRosPackage rec {
 
   meta = {
     description = "Perseus custom message definitions";
-    license = with lib.licenses; [ "TODO-CATKIN-PACKAGE-LICENSE" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/software/ros_ws/src/perseus_autonomy_bridge/package.xml
+++ b/software/ros_ws/src/perseus_autonomy_bridge/package.xml
@@ -5,7 +5,7 @@
   <version>0.0.0</version>
   <description>Autonomy Widget Bridge</description>
   <maintainer email="nguyenleminh1002@gmail.com">bocho0600</maintainer>
-  <license>TODO: License declaration</license>
+  <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/software/ros_ws/src/perseus_interfaces/package.xml
+++ b/software/ros_ws/src/perseus_interfaces/package.xml
@@ -7,7 +7,7 @@
   <description>Perseus custom message definitions</description>
 
   <maintainer email="brockjamesmorgan@gmail.com">brock</maintainer>
-  <license>TODO</license>
+  <license>MIT</license>
 
   <!-- Build system -->
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
Starting on getting rid of TODOs - changed both TODO license declarations in the package.xml files to MIT