### PR TITLE
feat: Added watch_dir to envrc to reload env

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,9 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.0.7; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.7/direnvrc" "sha256-bn8WANE5a91RusFmRI7kS751ApelG02nMcwRekC/qzc=" &>/dev/null
 fi
 
+watch_dir nix/
+watch_dir software/ros_ws/nix-packages/
+
 use flake .
 # print out autocomplete instructions
 printf '\033[0;33m' # orange text (makes it stand out more)

--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,8 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.0.7; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.7/direnvrc" "sha256-bn8WANE5a91RusFmRI7kS751ApelG02nMcwRekC/qzc=" &>/dev/null
 fi
 
+watch_file ./*.nix
+
 use flake .
 # print out autocomplete instructions
 printf '\033[0;33m' # orange text (makes it stand out more)


### PR DESCRIPTION
Just added watch_dir to the envrc so if any files in nix/ or software/ros_ws/nix-packages/ are changed the environment is reloaded (already happens with the `flake.nix` and `flake.lock` automatically). Prevents having to run `direnv reload` whenever running the `nix-package.sh` script. I think we *can* also use `watch_file *.nix` to reload whenever any nix file is changed, but this seems overkill and may become annoying. Thoughts on this are welcome.

Test using `touch nix/nixpkgs-config.nix` or similar and see the environment reload.