### PR TITLE
test(hi-can): Add gtest suite for serialization primitives and parameter groups

### DIFF
--- a/software/shared/hi-can/CMakeLists.txt
+++ b/software/shared/hi-can/CMakeLists.txt
@@ -91,8 +91,9 @@ if(BUILD_TESTING)
   find_package(GTest REQUIRED)
   include(GoogleTest)
 
-  set(HI_CAN_TEST_SOURCES tests/serializable_test.cpp
-                          tests/parameter_group_test.cpp)
+  set(HI_CAN_TEST_SOURCES
+      tests/serializable_test.cpp tests/parameter_group_test.cpp
+      tests/esc_parameter_group_test.cpp tests/filter_test.cpp)
 
   foreach(test_source ${HI_CAN_TEST_SOURCES})
     get_filename_component(test_name ${test_source} NAME_WE)
@@ -102,6 +103,9 @@ if(BUILD_TESTING)
     target_include_directories(
       ${test_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
                            ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-    gtest_discover_tests(${test_name})
+    # Defer test discovery to ctest time so cross-compile builds (where the
+    # test binary cannot be run on the build host) don't try to execute the
+    # binary during configure.
+    gtest_discover_tests(${test_name} DISCOVERY_MODE PRE_TEST)
   endforeach()
 endif()

--- a/software/shared/hi-can/CMakeLists.txt
+++ b/software/shared/hi-can/CMakeLists.txt
@@ -85,11 +85,23 @@ if(BUILD_SHARED_LIBS)
           DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 endif(BUILD_SHARED_LIBS)
 
-# TESTING find_package(GTest REQUIRED) enable_testing()
+# TESTING
+include(CTest)
+if(BUILD_TESTING)
+  find_package(GTest REQUIRED)
+  include(GoogleTest)
 
-# add_executable(interface_test tests/packet_manager_test.cpp)
-# target_link_libraries(interface_test GTest::gtest_main)
-# target_include_directories(interface_test PUBLIC
-# ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  set(HI_CAN_TEST_SOURCES tests/serializable_test.cpp
+                          tests/parameter_group_test.cpp)
 
-# include(GoogleTest) gtest_discover_tests(interface_test)
+  foreach(test_source ${HI_CAN_TEST_SOURCES})
+    get_filename_component(test_name ${test_source} NAME_WE)
+    add_executable(${test_name} ${test_source})
+    target_link_libraries(${test_name} PRIVATE ${PROJECT_NAME}
+                                               GTest::gtest_main)
+    target_include_directories(
+      ${test_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+                           ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    gtest_discover_tests(${test_name})
+  endforeach()
+endif()

--- a/software/shared/hi-can/tests/README.md
+++ b/software/shared/hi-can/tests/README.md
@@ -1,0 +1,46 @@
+# hi-can tests
+
+Unit tests for the hi-can serialization primitives and per-device parameter
+groups, built with GoogleTest.
+
+## What's covered
+
+- `serializable_test.cpp` — the foundational primitives every device serializer
+  is built on: `scaled_int32_t`, `scaled_int16_t`, `SimpleSerializable<T>`,
+  `wrapped_value_t<T>`. Round-trip and golden-byte assertions.
+- `parameter_group_test.cpp` — end-to-end test for one device's
+  `ParameterGroup` (VESC drive ESC). Uses a `FifoCanInterface` mock to inject
+  CAN frames and asserts the group's getters return the expected decoded
+  values.
+
+## Adding a test for a new device
+
+When you add a new `ParameterGroup` subclass, add an entry to
+`parameter_group_test.cpp` (or a new `<device>_test.cpp` file if the device
+warrants its own suite):
+
+1. Construct a `FifoCanInterface`, build a `PacketManager`, and `add_group`
+   your group. The `VescParameterGroupTest` fixture is a copy-paste starting
+   point.
+2. For each receive frame your device handles, write a test that queues a
+   golden-byte frame on the FIFO, calls `packet_manager->handle()`, and
+   asserts the group's getter returns the expected value. **Source the golden
+   bytes from your device datasheet, not by serializing through the code under
+   test** — otherwise a bug in the serializer hides itself.
+3. For each transmit frame, drive the group's setters, call
+   `handle(false, /*force_transmission=*/true)`, and assert the expected frame
+   ended up in the FIFO's `transmitted` queue.
+4. If you add a new `.cpp` file, list it in `HI_CAN_TEST_SOURCES` in the
+   parent `CMakeLists.txt`.
+
+## Running
+
+Tests run automatically via the nix build (`doCheck = true` in `default.nix`)
+or by hand inside a build directory:
+
+```bash
+cd software/shared/hi-can
+cmake -B build -DBUILD_TESTING=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```

--- a/software/shared/hi-can/tests/README.md
+++ b/software/shared/hi-can/tests/README.md
@@ -7,35 +7,74 @@ groups, built with GoogleTest.
 
 - `serializable_test.cpp` — the foundational primitives every device serializer
   is built on: `scaled_int32_t`, `scaled_int16_t`, `SimpleSerializable<T>`,
-  `wrapped_value_t<T>`. Round-trip and golden-byte assertions.
-- `parameter_group_test.cpp` — end-to-end test for one device's
-  `ParameterGroup` (VESC drive ESC). Uses a `FifoCanInterface` mock to inject
-  CAN frames and asserts the group's getters return the expected decoded
-  values.
+  `wrapped_value_t<T>`. Round-trip and golden-byte assertions. Also pins the
+  wire layout for `bucket_controller::{speed_t, current_t, magnet_t}` as a
+  worked example for new `SimpleSerializable<wrapped_value_t<T>>`-based
+  device typedefs (e.g. arm end-effector PWM).
+- `parameter_group_test.cpp` — end-to-end test for `VescParameterGroup`. Uses
+  the `FifoCanInterface` mock to inject CAN frames and asserts the group's
+  getters decoded as expected. Two `DISABLED_` tests document latent bugs in
+  the VESC serialize/deserialize paths (see the comments in the file); remove
+  the prefix when the underlying code is fixed.
+- `esc_parameter_group_test.cpp` — `EscParameterGroup`. The
+  `StartupTransmissionsRequestsLimits` test is the explicit regression catcher
+  for the PR #436 scenario where the LIMITS request was silently commented
+  out during a namespace-clash fix.
+- `filter_test.cpp` — `filter_t::matches` and `PacketManager` dispatch with
+  masked filters (e.g. `DEVICE_MASK`), so device tests that use partial
+  filters have a reference for the expected behaviour.
+
+Two helper headers live alongside the tests:
+
+- `test_helpers.hpp` — `be32`, `be16`, `concat` for building golden CAN
+  payloads.
+- `mock_can_interface.hpp` — `FifoCanInterface`, a `FilteredCanInterface`
+  backed by FIFO queues for inject/inspect.
 
 ## Adding a test for a new device
 
 When you add a new `ParameterGroup` subclass, add an entry to
 `parameter_group_test.cpp` (or a new `<device>_test.cpp` file if the device
-warrants its own suite):
+warrants its own suite). The `VescParameterGroupTest` and
+`EscParameterGroupTest` fixtures are both copy-paste templates.
 
 1. Construct a `FifoCanInterface`, build a `PacketManager`, and `add_group`
-   your group. The `VescParameterGroupTest` fixture is a copy-paste starting
-   point.
+   your group. Clear `bus.transmitted` in `SetUp` after `add_group` if the
+   group has any zero-interval transmissions, otherwise the first
+   `handle()` call will emit stray frames.
 2. For each receive frame your device handles, write a test that queues a
-   golden-byte frame on the FIFO, calls `packet_manager->handle()`, and
-   asserts the group's getter returns the expected value. **Source the golden
-   bytes from your device datasheet, not by serializing through the code under
-   test** — otherwise a bug in the serializer hides itself.
+   golden-byte frame on the FIFO, calls `packet_manager->handle_receive()`,
+   and asserts the group's getter returns the expected value. **Source the
+   golden bytes from your device datasheet, not by serializing through the
+   code under test** — otherwise a bug in the serializer hides itself.
 3. For each transmit frame, drive the group's setters, call
-   `handle(false, /*force_transmission=*/true)`, and assert the expected frame
-   ended up in the FIFO's `transmitted` queue.
-4. If you add a new `.cpp` file, list it in `HI_CAN_TEST_SOURCES` in the
-   parent `CMakeLists.txt`.
+   `handle(false, /*force_transmission=*/true)`, and search the
+   `transmitted` queue by address rather than indexing positionally — a
+   group may emit multiple frames per cycle, and ordering is not part of
+   the contract.
+4. If you add a new `.cpp` file, **`git add` it** (staging is enough — no
+   commit needed) before running `nix build`. The flake source filter uses
+   `git ls-files`, so untracked test files are invisible to the build and
+   `add_executable` will fail with "Cannot find source file". List the new
+   path in `HI_CAN_TEST_SOURCES` in the parent `CMakeLists.txt`.
+
+## Not yet covered
+
+- **Timeout / timeout-recovery callbacks.** `PacketManager` reads
+  `steady_clock::now()` directly inside `handle_receive`, so timeout tests
+  would either need a clock abstraction injected into `PacketManager` or a
+  `std::this_thread::sleep_for` (flaky, slow). Deferred until that refactor
+  is done.
 
 ## Running
 
-Tests run automatically via the nix build (`doCheck = true` in `default.nix`)
+Tests run automatically via the nix build (`doCheck = true` in
+`default.nix`):
+
+```bash
+nix build .#pkgs.hi-can
+```
+
 or by hand inside a build directory:
 
 ```bash

--- a/software/shared/hi-can/tests/esc_parameter_group_test.cpp
+++ b/software/shared/hi-can/tests/esc_parameter_group_test.cpp
@@ -1,0 +1,148 @@
+// Legacy drive ESC parameter group tests.
+//
+// The startup-transmissions case is the regression test that would have
+// caught PR #436 deleting the LIMITS-request behaviour from
+// EscParameterGroup::get_startup_transmissions(). Keep it.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "hi_can.hpp"
+#include "hi_can_address.hpp"
+#include "hi_can_packet.hpp"
+#include "hi_can_parameter.hpp"
+#include "mock_can_interface.hpp"
+
+using namespace hi_can;
+using namespace hi_can::parameters::legacy::drive::motors;
+// Bring the addressing-side enums (esc::parameter, mcb::groups, device)
+// into scope for test bodies. The same namespace tree exists under
+// `parameters::legacy::drive::motors` for the group/struct types.
+using namespace hi_can::addressing::legacy::drive::motors;
+using hi_can_test::FifoCanInterface;
+
+namespace
+{
+    // Build the device address for FRONT_LEFT_MOTOR's ESC. The legacy
+    // addressing layout is system|subsystem|device|group|parameter; for the
+    // ESC parameter group, the group is `mcb::groups::ESC` and parameters
+    // are SPEED / LIMITS / STATUS / POSITION.
+    addressing::legacy::address_t make_device_address()
+    {
+        using namespace addressing::legacy;
+        return address_t(
+            drive::SYSTEM_ID,
+            drive::motors::SUBSYSTEM_ID,
+            static_cast<uint8_t>(drive::motors::device::FRONT_LEFT_MOTOR));
+    }
+
+    addressing::flagged_address_t parameter_address(
+        const addressing::legacy::address_t& device_address,
+        addressing::legacy::drive::motors::esc::parameter param,
+        bool is_rtr = false)
+    {
+        using namespace addressing::legacy;
+        return addressing::flagged_address_t{
+            address_t(device_address,
+                      static_cast<uint8_t>(drive::motors::mcb::groups::ESC),
+                      static_cast<uint8_t>(param)),
+            is_rtr,
+        };
+    }
+}  // namespace
+
+class EscParameterGroupTest : public ::testing::Test
+{
+protected:
+    addressing::legacy::address_t device_address = make_device_address();
+    FifoCanInterface bus;
+    std::unique_ptr<PacketManager> packet_manager;
+    std::unique_ptr<EscParameterGroup> group;
+
+    void SetUp() override
+    {
+        packet_manager = std::make_unique<PacketManager>(bus);
+        group = std::make_unique<EscParameterGroup>(device_address);
+        packet_manager->add_group(*group);
+        decltype(bus.transmitted){}.swap(bus.transmitted);
+    }
+};
+
+// Regression test for PR #436. EscParameterGroup::get_startup_transmissions
+// must emit exactly one RTR packet at the LIMITS address. PR #436 commented
+// out that body when fighting a namespace clash, silently disabling the
+// limits-request on every drive ESC at boot. This test fires loudly if any
+// future change does the same.
+TEST_F(EscParameterGroupTest, StartupTransmissionsRequestsLimits)
+{
+    const auto packets = group->get_startup_transmissions();
+    ASSERT_EQ(packets.size(), 1u) << "expected one RTR packet for LIMITS";
+
+    const auto expected_address = parameter_address(
+        device_address, esc::parameter::LIMITS, /*is_rtr=*/true);
+    EXPECT_EQ(packets.front().get_address(), expected_address);
+    EXPECT_TRUE(packets.front().get_is_rtr());
+    EXPECT_EQ(packets.front().get_data_len(), 0u);
+}
+
+// Speed frame is a packed POD: enabled (bool, 1 byte), direction (int8),
+// speed (int16 LE). Native byte order — pin little-endian.
+TEST_F(EscParameterGroupTest, DeserializesSpeed)
+{
+    if constexpr (std::endian::native != std::endian::little)
+        GTEST_SKIP() << "Host is not little-endian.";
+
+    // Bytes: enabled=true, direction=FORWARD(1), speed=0x0123 LE → {0x23, 0x01}
+    const std::vector<uint8_t> payload = {0x01, 0x01, 0x23, 0x01};
+    bus.queue_receive(Packet{
+        parameter_address(device_address, esc::parameter::SPEED),
+        payload});
+    packet_manager->handle_receive();
+
+    auto& s = group->get_speed();
+    EXPECT_TRUE(s.enabled);
+    EXPECT_EQ(static_cast<int8_t>(s.direction),
+              static_cast<int8_t>(motor_direction::FORWARD));
+    EXPECT_EQ(s.speed, 0x0123);
+}
+
+// Status frame: ready (bool, 1 byte), real_speed (int16 LE), real_current
+// (int16 LE).
+TEST_F(EscParameterGroupTest, DeserializesStatus)
+{
+    if constexpr (std::endian::native != std::endian::little)
+        GTEST_SKIP() << "Host is not little-endian.";
+
+    // ready=true, real_speed=-100 (0xFF9C LE → {0x9C, 0xFF}), real_current=42 (LE → {0x2A, 0x00})
+    const std::vector<uint8_t> payload = {0x01, 0x9C, 0xFF, 0x2A, 0x00};
+    bus.queue_receive(Packet{
+        parameter_address(device_address, esc::parameter::STATUS),
+        payload});
+    packet_manager->handle_receive();
+
+    auto& s = group->get_status();
+    EXPECT_TRUE(s.ready);
+    EXPECT_EQ(s.real_speed, -100);
+    EXPECT_EQ(s.real_current, 42);
+}
+
+// A frame for the same address but a different *device* must be ignored.
+TEST_F(EscParameterGroupTest, IgnoresFramesForOtherDevice)
+{
+    using namespace addressing::legacy;
+    const address_t other_device(
+        drive::SYSTEM_ID,
+        drive::motors::SUBSYSTEM_ID,
+        static_cast<uint8_t>(drive::motors::device::FRONT_RIGHT_MOTOR));
+    const auto other_address = parameter_address(
+        other_device, esc::parameter::SPEED);
+
+    bus.queue_receive(Packet{other_address, std::vector<uint8_t>{0x01, 0x01, 0xFF, 0x7F}});
+    packet_manager->handle_receive();
+
+    auto& s = group->get_speed();
+    EXPECT_FALSE(s.enabled);
+    EXPECT_EQ(s.speed, 0);
+}

--- a/software/shared/hi-can/tests/filter_test.cpp
+++ b/software/shared/hi-can/tests/filter_test.cpp
@@ -1,0 +1,160 @@
+// Tests for the FilteredCanInterface / PacketManager filter-matching path.
+//
+// Most existing device parameter groups use exact-address filters, but the
+// arm code introduced in PR #436 uses masked filters (e.g. `mask =
+// DEVICE_MASK`) so a single callback handles every parameter on a given
+// device. Pinning the mask semantics here means downstream tests can rely
+// on the dispatch behaviour without re-deriving it.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "hi_can.hpp"
+#include "hi_can_address.hpp"
+#include "hi_can_packet.hpp"
+#include "mock_can_interface.hpp"
+
+using namespace hi_can;
+using namespace hi_can::addressing;
+using hi_can_test::FifoCanInterface;
+
+namespace
+{
+    // Helper: build a flagged extended CAN address from a raw value.
+    constexpr flagged_address_t flagged(raw_address_t addr)
+    {
+        return flagged_address_t{addr};
+    }
+}  // namespace
+
+// matches() with the default MASK_ALL mask requires every bit to match.
+TEST(Filter, ExactMatchRejectsDifferentAddress)
+{
+    const filter_t f{.address = flagged(0x12345678)};
+    EXPECT_TRUE(f.matches(flagged(0x12345678)));
+    EXPECT_FALSE(f.matches(flagged(0x12345679)));
+    EXPECT_FALSE(f.matches(flagged(0x12340678)));
+}
+
+// With DEVICE_MASK (system|subsystem|device bits only), all parameter
+// groups and parameters of a given device match the same filter.
+TEST(Filter, DeviceMaskMatchesAllGroupsAndParameters)
+{
+    // Pick an arbitrary device: system=3, subsystem=1, device=5.
+    const standard_address_t device_address{
+        /*system=*/3, /*subsystem=*/1, /*device=*/5};
+    const filter_t f{
+        .address = flagged_address_t(static_cast<raw_address_t>(device_address)),
+        .mask = DEVICE_MASK,
+    };
+
+    // Any group/parameter on that device must match.
+    const standard_address_t same_device_a{3, 1, 5, /*group=*/0x00, /*parameter=*/0x00};
+    const standard_address_t same_device_b{3, 1, 5, /*group=*/0xAB, /*parameter=*/0xCD};
+    EXPECT_TRUE(f.matches(flagged_address_t(static_cast<raw_address_t>(same_device_a))));
+    EXPECT_TRUE(f.matches(flagged_address_t(static_cast<raw_address_t>(same_device_b))));
+
+    // A different device (device=6) must NOT match.
+    const standard_address_t other_device{3, 1, 6, 0x00, 0x00};
+    EXPECT_FALSE(f.matches(flagged_address_t(static_cast<raw_address_t>(other_device))));
+
+    // Same device but different subsystem also must not match.
+    const standard_address_t other_subsystem{3, 2, 5, 0x00, 0x00};
+    EXPECT_FALSE(f.matches(flagged_address_t(static_cast<raw_address_t>(other_subsystem))));
+}
+
+// PacketManager + FilteredCanInterface end-to-end: callbacks registered
+// with a masked filter fire for every matching address.
+TEST(Filter, PacketManagerDispatchesMaskedFilter)
+{
+    FifoCanInterface bus;
+    PacketManager packet_manager(bus);
+
+    const standard_address_t device_address{3, 1, 5};
+    const filter_t device_filter{
+        .address = flagged_address_t(static_cast<raw_address_t>(device_address)),
+        .mask = DEVICE_MASK,
+    };
+
+    int call_count = 0;
+    Packet last_packet;
+    packet_manager.set_callback(
+        device_filter,
+        PacketManager::callback_config_t{
+            .data_callback = [&](const Packet& p)
+            {
+                ++call_count;
+                last_packet = p;
+            },
+        });
+
+    // Inject three frames at three different (group, parameter) pairs on
+    // the matching device.
+    for (uint8_t param : {uint8_t{0x00}, uint8_t{0x11}, uint8_t{0xFF}})
+    {
+        const standard_address_t addr{3, 1, 5, /*group=*/0x42, param};
+        bus.queue_receive(Packet{
+            flagged_address_t(static_cast<raw_address_t>(addr)),
+            std::vector<uint8_t>{param},
+        });
+    }
+
+    // Inject a frame for a non-matching device — must be filtered out.
+    const standard_address_t other_addr{3, 1, 6, 0x00, 0x00};
+    bus.queue_receive(Packet{
+        flagged_address_t(static_cast<raw_address_t>(other_addr)),
+        std::vector<uint8_t>{0xDE},
+    });
+
+    packet_manager.handle_receive();
+
+    EXPECT_EQ(call_count, 3) << "masked filter must fire once per matching frame";
+    // Last frame seen should be the param=0xFF one.
+    ASSERT_EQ(last_packet.get_data_len(), 1u);
+    EXPECT_EQ(last_packet.get_data().front(), 0xFFu);
+}
+
+// When two filters cover the same address with different mask specificity,
+// PacketManager picks the more specific one (filter_t's operator<=> sorts
+// greater-mask filters first inside the std::set).
+TEST(Filter, MoreSpecificFilterWinsOnOverlap)
+{
+    FifoCanInterface bus;
+    PacketManager packet_manager(bus);
+
+    const standard_address_t device_address{3, 1, 5};
+    const standard_address_t specific_address{3, 1, 5, /*group=*/0x42, /*parameter=*/0xAB};
+
+    int generic_calls = 0;
+    int specific_calls = 0;
+
+    packet_manager.set_callback(
+        filter_t{
+            .address = flagged_address_t(static_cast<raw_address_t>(device_address)),
+            .mask = DEVICE_MASK,
+        },
+        PacketManager::callback_config_t{
+            .data_callback = [&](const Packet&)
+            { ++generic_calls; },
+        });
+    packet_manager.set_callback(
+        filter_t{
+            .address = flagged_address_t(static_cast<raw_address_t>(specific_address)),
+            // MASK_ALL is the default — explicit here for documentation.
+            .mask = MASK_ALL,
+        },
+        PacketManager::callback_config_t{
+            .data_callback = [&](const Packet&)
+            { ++specific_calls; },
+        });
+
+    bus.queue_receive(Packet{
+        flagged_address_t(static_cast<raw_address_t>(specific_address)),
+        std::vector<uint8_t>{},
+    });
+    packet_manager.handle_receive();
+
+    EXPECT_EQ(specific_calls, 1) << "exact filter should win over masked one";
+    EXPECT_EQ(generic_calls, 0);
+}

--- a/software/shared/hi-can/tests/mock_can_interface.hpp
+++ b/software/shared/hi-can/tests/mock_can_interface.hpp
@@ -1,0 +1,50 @@
+// Mock FilteredCanInterface backed by FIFO queues. Used by every
+// parameter-group / filter test to inject and inspect CAN frames without
+// touching a real platform CAN driver.
+//
+// Mirrors SoftwareFilteredCanInterface::receive: applies the registered
+// filters, then dispatches to the receive callback PacketManager installs
+// at construction. Without that dispatch the PacketManager's
+// `_handle_received_packet` would never be called and tests would silently
+// observe defaults.
+
+#pragma once
+
+#include <optional>
+#include <queue>
+
+#include "hi_can.hpp"
+#include "hi_can_packet.hpp"
+
+namespace hi_can_test
+{
+    class FifoCanInterface : public hi_can::FilteredCanInterface
+    {
+    public:
+        void transmit(const hi_can::Packet& packet) override
+        {
+            transmitted.push(packet);
+        }
+
+        std::optional<hi_can::Packet> receive(bool blocking = false) override
+        {
+            (void)blocking;
+            if (to_receive.empty())
+                return std::nullopt;
+            hi_can::Packet p = to_receive.front();
+            to_receive.pop();
+
+            if (!address_matches_filters(p.get_address()))
+                return std::nullopt;
+
+            if (_receive_callback)
+                _receive_callback(p);
+            return p;
+        }
+
+        void queue_receive(const hi_can::Packet& p) { to_receive.push(p); }
+
+        std::queue<hi_can::Packet> to_receive;
+        std::queue<hi_can::Packet> transmitted;
+    };
+}  // namespace hi_can_test

--- a/software/shared/hi-can/tests/parameter_group_test.cpp
+++ b/software/shared/hi-can/tests/parameter_group_test.cpp
@@ -1,0 +1,290 @@
+// End-to-end test for a real device's ParameterGroup, using the VESC drive ESC
+// as the worked example. This is the template every device test should follow:
+// queue golden-byte CAN frames on a mock interface, run PacketManager::handle,
+// and assert the group's getters decoded as expected.
+//
+// Golden bytes here are derived directly from the wire-format scaling factors
+// documented in hi_can_parameter.cpp (rpm: int32 BE / 1, current: int16 BE /
+// 10, etc.), NOT by round-tripping through the code under test. That would
+// hide bugs in the serializer.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <queue>
+#include <vector>
+
+#include "hi_can.hpp"
+#include "hi_can_address.hpp"
+#include "hi_can_packet.hpp"
+#include "hi_can_parameter.hpp"
+
+using namespace hi_can;
+using namespace hi_can::parameters;
+using namespace hi_can::parameters::drive::vesc;
+
+namespace
+{
+    // Minimal FilteredCanInterface backed by FIFO queues. Replaces the
+    // platform CAN driver in tests so we can inject and inspect frames.
+    // Mirrors SoftwareFilteredCanInterface::receive: applies the registered
+    // filters and dispatches to the receive callback that PacketManager
+    // installs at construction.
+    class FifoCanInterface : public FilteredCanInterface
+    {
+    public:
+        void transmit(const Packet& packet) override
+        {
+            transmitted.push(packet);
+        }
+        std::optional<Packet> receive(bool blocking = false) override
+        {
+            (void)blocking;
+            if (to_receive.empty())
+                return std::nullopt;
+            Packet p = to_receive.front();
+            to_receive.pop();
+
+            if (!address_matches_filters(p.get_address()))
+                return std::nullopt;
+
+            if (_receive_callback)
+                _receive_callback(p);
+            return p;
+        }
+
+        void queue_receive(const Packet& p) { to_receive.push(p); }
+
+        std::queue<Packet> to_receive;
+        std::queue<Packet> transmitted;
+    };
+
+    // Pack an int32 in network byte order into a byte vector. Defined locally
+    // so we don't depend on the implementation under test for our golden
+    // bytes.
+    std::vector<uint8_t> be32(int32_t v)
+    {
+        return {
+            static_cast<uint8_t>((v >> 24) & 0xFF),
+            static_cast<uint8_t>((v >> 16) & 0xFF),
+            static_cast<uint8_t>((v >> 8) & 0xFF),
+            static_cast<uint8_t>(v & 0xFF),
+        };
+    }
+    std::vector<uint8_t> be16(int16_t v)
+    {
+        return {
+            static_cast<uint8_t>((v >> 8) & 0xFF),
+            static_cast<uint8_t>(v & 0xFF),
+        };
+    }
+    std::vector<uint8_t> concat(std::initializer_list<std::vector<uint8_t>> parts)
+    {
+        std::vector<uint8_t> out;
+        for (const auto& p : parts)
+            out.insert(out.end(), p.begin(), p.end());
+        return out;
+    }
+}  // namespace
+
+namespace
+{
+    constexpr uint8_t kVescId = 0x01;
+
+    // Build the flagged address for a given VESC command for our test VESC ID.
+    addressing::flagged_address_t vesc_address(addressing::drive::vesc::command_id cmd)
+    {
+        using namespace addressing::drive::vesc;
+        return static_cast<addressing::flagged_address_t>(address_t(kVescId, cmd));
+    }
+}  // namespace
+
+class VescParameterGroupTest : public ::testing::Test
+{
+protected:
+    FifoCanInterface bus;
+    std::unique_ptr<PacketManager> packet_manager;
+    std::unique_ptr<VescParameterGroup> group;
+
+    void SetUp() override
+    {
+        packet_manager = std::make_unique<PacketManager>(bus);
+        group = std::make_unique<VescParameterGroup>(kVescId);
+        packet_manager->add_group(*group);
+    }
+
+    // Inject a frame at the given VESC address and run one handle cycle.
+    void inject(addressing::drive::vesc::command_id cmd,
+                const std::vector<uint8_t>& payload)
+    {
+        bus.queue_receive(Packet{vesc_address(cmd), payload});
+        packet_manager->handle();
+    }
+};
+
+// Status 1: rpm (int32 BE, scale 1), current (int16 BE, scale 10),
+// duty_cycle (int16 BE, scale 1000). 8 bytes total.
+TEST_F(VescParameterGroupTest, DeserializesStatus1)
+{
+    // rpm = 2500, current = 4.2 A, duty_cycle = 0.157 (15.7%)
+    const auto payload = concat({
+        be32(2500),    // rpm
+        be16(42),      // current * 10
+        be16(157),     // duty_cycle * 1000
+    });
+
+    inject(addressing::drive::vesc::command_id::STATUS_1, payload);
+
+    auto& s = group->get_status1();
+    EXPECT_DOUBLE_EQ(s.rpm, 2500.0);
+    EXPECT_DOUBLE_EQ(s.current, 4.2);
+    EXPECT_DOUBLE_EQ(s.duty_cycle, 0.157);
+}
+
+// Status 2: amp-hours and amp-hours-charged, both int32 BE scaled by 10000.
+TEST_F(VescParameterGroupTest, DeserializesStatus2)
+{
+    const auto payload = concat({
+        be32(15000),  // ah * 10000 → 1.5 Ah
+        be32(2500),   // ah_charge * 10000 → 0.25 Ah
+    });
+
+    inject(addressing::drive::vesc::command_id::STATUS_2, payload);
+
+    auto& s = group->get_status2();
+    EXPECT_DOUBLE_EQ(s.ah, 1.5);
+    EXPECT_DOUBLE_EQ(s.ah_charge, 0.25);
+}
+
+// Status 4: temp_fet/temp_motor/current_in (int16 BE / 10), pid_pos (int16 BE / 50).
+// Only positive values exercised here — status_4's int16 fields drop the
+// `static_cast<int16_t>` after `ntohs` that status_1 has, so negative wire
+// values currently decode as huge positives. See
+// DISABLED_DeserializesStatus4NegativeCurrentIn below.
+TEST_F(VescParameterGroupTest, DeserializesStatus4)
+{
+    const auto payload = concat({
+        be16(425),    // temp_fet * 10 → 42.5 C
+        be16(380),    // temp_motor * 10 → 38.0 C
+        be16(127),    // current_in * 10 → 12.7 A
+        be16(9000),   // pid_pos * 50 → 180.0 deg
+    });
+
+    inject(addressing::drive::vesc::command_id::STATUS_4, payload);
+
+    auto& s = group->get_status4();
+    EXPECT_DOUBLE_EQ(s.temp_fet, 42.5);
+    EXPECT_DOUBLE_EQ(s.temp_motor, 38.0);
+    EXPECT_DOUBLE_EQ(s.current_in, 12.7);
+    EXPECT_DOUBLE_EQ(s.pid_pos, 180.0);
+}
+
+// status_4_t::deserialize_data computes `ntohs(raw_data.current_in) / 10.0`
+// without casting through int16_t. Because `ntohs` returns `uint16_t`, the
+// sign bit is lost — a wire value of -127 (0xFF81) decodes as 65409, then
+// /10 = 6540.9. status_1 handles this correctly via
+// `static_cast<int16_t>(ntohs(...))`; the same fix is needed in
+// status_4_t/status_5_t/status_6_t (every int16 field that can be negative).
+//
+// Status1 also has a deserialize for negative current which DOES work — see
+// DeserializesStatus1NegativeCurrent below for the working case.
+//
+// When the cast is added, remove the DISABLED_ prefix.
+TEST_F(VescParameterGroupTest, DISABLED_DeserializesStatus4NegativeCurrentIn)
+{
+    const auto payload = concat({
+        be16(0),
+        be16(0),
+        be16(-127),  // current_in * 10 → -12.7 A
+        be16(0),
+    });
+    inject(addressing::drive::vesc::command_id::STATUS_4, payload);
+    EXPECT_DOUBLE_EQ(group->get_status4().current_in, -12.7);
+}
+
+// status_1's current field correctly handles negative values because its
+// deserialize uses `static_cast<int16_t>(ntohs(...))`. Pinning this so the
+// fix to status_4 doesn't accidentally regress status_1.
+TEST_F(VescParameterGroupTest, DeserializesStatus1NegativeCurrent)
+{
+    const auto payload = concat({
+        be32(0),
+        be16(-42),   // current * 10 → -4.2 A
+        be16(0),
+    });
+    inject(addressing::drive::vesc::command_id::STATUS_1, payload);
+    EXPECT_DOUBLE_EQ(group->get_status1().current, -4.2);
+}
+
+// Status 5: tachometer (int32 BE / 6), volts_in (int16 BE / 10), 2 bytes pad.
+TEST_F(VescParameterGroupTest, DeserializesStatus5)
+{
+    const auto payload = concat({
+        be32(60000),  // tachometer / 6 → 10000.0
+        be16(480),    // volts_in / 10 → 48.0 V
+        {0x00, 0x00},
+    });
+
+    inject(addressing::drive::vesc::command_id::STATUS_5, payload);
+
+    auto& s = group->get_status5();
+    EXPECT_DOUBLE_EQ(s.tachometer, 10000.0);
+    EXPECT_DOUBLE_EQ(s.volts_in, 48.0);
+}
+
+// A frame addressed to a different VESC ID must not mutate this group.
+TEST_F(VescParameterGroupTest, IgnoresFramesForOtherVescId)
+{
+    using namespace addressing::drive::vesc;
+    const auto other_address = static_cast<addressing::flagged_address_t>(
+        address_t(static_cast<uint8_t>(kVescId + 1), command_id::STATUS_1));
+
+    bus.queue_receive(Packet{other_address, concat({be32(9999), be16(999), be16(999)})});
+    packet_manager->handle();
+
+    auto& s = group->get_status1();
+    EXPECT_DOUBLE_EQ(s.rpm, 0.0);
+    EXPECT_DOUBLE_EQ(s.current, 0.0);
+    EXPECT_DOUBLE_EQ(s.duty_cycle, 0.0);
+}
+
+// Setting a SET_RPM value drives a transmission with the correct big-endian
+// scaled int32. set_rpm_t uses scaled_int32_t<1.0> so 2500 rpm → BE int32 2500.
+TEST_F(VescParameterGroupTest, SetRpmTransmitsScaledBigEndian)
+{
+    using namespace addressing::drive::vesc;
+
+    group->get_set_rpm().value = 2500.0;
+    // Force transmit regardless of interval.
+    packet_manager->handle(/*should_block=*/false, /*should_force_transmission=*/true);
+
+    ASSERT_FALSE(bus.transmitted.empty()) << "expected at least one transmission";
+    const Packet& tx = bus.transmitted.front();
+    EXPECT_EQ(tx.get_address(),
+              static_cast<addressing::flagged_address_t>(address_t(kVescId, command_id::SET_RPM)));
+    EXPECT_EQ(tx.get_data(), be32(2500));
+}
+
+// Round-trip is currently broken: status_*_t::serialize_data() in
+// hi_can_parameter.cpp applies htons/htonl BEFORE scaling
+// (e.g. `raw_data.current = htons(current) * 10.0;`) so serialize → deserialize
+// does NOT return the original value for any status struct except status_1's
+// rpm field (which has no fractional scaling).
+//
+// When that serialize bug is fixed (multiply, then htons; see TODO in
+// status_5_t::serialize_data) remove the DISABLED_ prefix from this test.
+TEST_F(VescParameterGroupTest, DISABLED_Status1RoundTripsThroughSerialize)
+{
+    status_1_t in;
+    in.rpm = 2500;
+    in.current = 4.2;
+    in.duty_cycle = 0.157;
+
+    status_1_t out;
+    out.deserialize_data(in.serialize_data());
+
+    EXPECT_DOUBLE_EQ(out.rpm, 2500.0);
+    EXPECT_DOUBLE_EQ(out.current, 4.2);
+    EXPECT_DOUBLE_EQ(out.duty_cycle, 0.157);
+}

--- a/software/shared/hi-can/tests/parameter_group_test.cpp
+++ b/software/shared/hi-can/tests/parameter_group_test.cpp
@@ -129,9 +129,9 @@ TEST_F(VescParameterGroupTest, DeserializesStatus1)
 {
     // rpm = 2500, current = 4.2 A, duty_cycle = 0.157 (15.7%)
     const auto payload = concat({
-        be32(2500),    // rpm
-        be16(42),      // current * 10
-        be16(157),     // duty_cycle * 1000
+        be32(2500),  // rpm
+        be16(42),    // current * 10
+        be16(157),   // duty_cycle * 1000
     });
 
     inject(addressing::drive::vesc::command_id::STATUS_1, payload);
@@ -165,10 +165,10 @@ TEST_F(VescParameterGroupTest, DeserializesStatus2)
 TEST_F(VescParameterGroupTest, DeserializesStatus4)
 {
     const auto payload = concat({
-        be16(425),    // temp_fet * 10 → 42.5 C
-        be16(380),    // temp_motor * 10 → 38.0 C
-        be16(127),    // current_in * 10 → 12.7 A
-        be16(9000),   // pid_pos * 50 → 180.0 deg
+        be16(425),   // temp_fet * 10 → 42.5 C
+        be16(380),   // temp_motor * 10 → 38.0 C
+        be16(127),   // current_in * 10 → 12.7 A
+        be16(9000),  // pid_pos * 50 → 180.0 deg
     });
 
     inject(addressing::drive::vesc::command_id::STATUS_4, payload);
@@ -210,7 +210,7 @@ TEST_F(VescParameterGroupTest, DeserializesStatus1NegativeCurrent)
 {
     const auto payload = concat({
         be32(0),
-        be16(-42),   // current * 10 → -4.2 A
+        be16(-42),  // current * 10 → -4.2 A
         be16(0),
     });
     inject(addressing::drive::vesc::command_id::STATUS_1, payload);

--- a/software/shared/hi-can/tests/parameter_group_test.cpp
+++ b/software/shared/hi-can/tests/parameter_group_test.cpp
@@ -1,105 +1,54 @@
-// End-to-end test for a real device's ParameterGroup, using the VESC drive ESC
-// as the worked example. This is the template every device test should follow:
-// queue golden-byte CAN frames on a mock interface, run PacketManager::handle,
-// and assert the group's getters decoded as expected.
+// End-to-end test for a real device's ParameterGroup, using the VESC drive
+// ESC as the worked example. This is the template every device test should
+// follow: queue golden-byte CAN frames on a mock interface, run
+// PacketManager::handle_receive(), and assert the group's getters decoded
+// as expected.
 //
-// Golden bytes here are derived directly from the wire-format scaling factors
-// documented in hi_can_parameter.cpp (rpm: int32 BE / 1, current: int16 BE /
-// 10, etc.), NOT by round-tripping through the code under test. That would
-// hide bugs in the serializer.
+// Golden bytes here are derived directly from the wire-format scaling
+// factors documented in hi_can_parameter.cpp (rpm: int32 BE / 1, current:
+// int16 BE / 10, etc.), NOT by round-tripping through the code under test.
+// That would hide bugs in the serializer.
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
-#include <optional>
-#include <queue>
+#include <memory>
 #include <vector>
 
 #include "hi_can.hpp"
 #include "hi_can_address.hpp"
 #include "hi_can_packet.hpp"
 #include "hi_can_parameter.hpp"
+#include "mock_can_interface.hpp"
+#include "test_helpers.hpp"
 
 using namespace hi_can;
 using namespace hi_can::parameters;
 using namespace hi_can::parameters::drive::vesc;
+using hi_can_test::be16;
+using hi_can_test::be32;
+using hi_can_test::concat;
+using hi_can_test::FifoCanInterface;
 
 namespace
 {
-    // Minimal FilteredCanInterface backed by FIFO queues. Replaces the
-    // platform CAN driver in tests so we can inject and inspect frames.
-    // Mirrors SoftwareFilteredCanInterface::receive: applies the registered
-    // filters and dispatches to the receive callback that PacketManager
-    // installs at construction.
-    class FifoCanInterface : public FilteredCanInterface
-    {
-    public:
-        void transmit(const Packet& packet) override
-        {
-            transmitted.push(packet);
-        }
-        std::optional<Packet> receive(bool blocking = false) override
-        {
-            (void)blocking;
-            if (to_receive.empty())
-                return std::nullopt;
-            Packet p = to_receive.front();
-            to_receive.pop();
-
-            if (!address_matches_filters(p.get_address()))
-                return std::nullopt;
-
-            if (_receive_callback)
-                _receive_callback(p);
-            return p;
-        }
-
-        void queue_receive(const Packet& p) { to_receive.push(p); }
-
-        std::queue<Packet> to_receive;
-        std::queue<Packet> transmitted;
-    };
-
-    // Pack an int32 in network byte order into a byte vector. Defined locally
-    // so we don't depend on the implementation under test for our golden
-    // bytes.
-    std::vector<uint8_t> be32(int32_t v)
-    {
-        return {
-            static_cast<uint8_t>((v >> 24) & 0xFF),
-            static_cast<uint8_t>((v >> 16) & 0xFF),
-            static_cast<uint8_t>((v >> 8) & 0xFF),
-            static_cast<uint8_t>(v & 0xFF),
-        };
-    }
-    std::vector<uint8_t> be16(int16_t v)
-    {
-        return {
-            static_cast<uint8_t>((v >> 8) & 0xFF),
-            static_cast<uint8_t>(v & 0xFF),
-        };
-    }
-    std::vector<uint8_t> concat(std::initializer_list<std::vector<uint8_t>> parts)
-    {
-        std::vector<uint8_t> out;
-        for (const auto& p : parts)
-            out.insert(out.end(), p.begin(), p.end());
-        return out;
-    }
-}  // namespace
-
-namespace
-{
-    constexpr uint8_t kVescId = 0x01;
+    constexpr uint8_t TEST_VESC_ID = 0x01;
 
     // Build the flagged address for a given VESC command for our test VESC ID.
     addressing::flagged_address_t vesc_address(addressing::drive::vesc::command_id cmd)
     {
         using namespace addressing::drive::vesc;
-        return static_cast<addressing::flagged_address_t>(address_t(kVescId, cmd));
+        return static_cast<addressing::flagged_address_t>(address_t(TEST_VESC_ID, cmd));
     }
 }  // namespace
 
+// Member order matters: PacketManager holds lambdas that capture
+// `group.get()`, and VescParameterGroup is what owns the storage those
+// lambdas write into. C++ destroys members in reverse declaration order, so
+// declaring `group` last means it dies *first* — before `packet_manager`'s
+// callbacks can fire from any final destructor work. The production arm code
+// (see PR #436 review) gets this ordering wrong; this fixture is the right
+// shape to copy.
 class VescParameterGroupTest : public ::testing::Test
 {
 protected:
@@ -110,16 +59,24 @@ protected:
     void SetUp() override
     {
         packet_manager = std::make_unique<PacketManager>(bus);
-        group = std::make_unique<VescParameterGroup>(kVescId);
+        group = std::make_unique<VescParameterGroup>(TEST_VESC_ID);
         packet_manager->add_group(*group);
+        // add_group sets last_transmitted = now for every transmission, so
+        // a subsequent handle() with a zero-interval transmission would emit
+        // a frame. Clear the queue so deserialize tests can rely on a clean
+        // transmitted-queue state, and so transmit tests only see frames
+        // they themselves provoked.
+        decltype(bus.transmitted){}.swap(bus.transmitted);
     }
 
-    // Inject a frame at the given VESC address and run one handle cycle.
+    // Inject a frame and run only the receive half of the manager. We
+    // deliberately do NOT call handle() (which also runs handle_transmit)
+    // so receive tests cannot be polluted by interval-driven transmissions.
     void inject(addressing::drive::vesc::command_id cmd,
                 const std::vector<uint8_t>& payload)
     {
         bus.queue_receive(Packet{vesc_address(cmd), payload});
-        packet_manager->handle();
+        packet_manager->handle_receive();
     }
 };
 
@@ -127,19 +84,32 @@ protected:
 // duty_cycle (int16 BE, scale 1000). 8 bytes total.
 TEST_F(VescParameterGroupTest, DeserializesStatus1)
 {
-    // rpm = 2500, current = 4.2 A, duty_cycle = 0.157 (15.7%)
     const auto payload = concat({
         be32(2500),  // rpm
-        be16(42),    // current * 10
-        be16(157),   // duty_cycle * 1000
+        be16(42),    // current * 10 → 4.2 A
+        be16(157),   // duty_cycle * 1000 → 0.157
     });
 
     inject(addressing::drive::vesc::command_id::STATUS_1, payload);
 
     auto& s = group->get_status1();
-    EXPECT_DOUBLE_EQ(s.rpm, 2500.0);
+    EXPECT_EQ(s.rpm, 2500.0);
     EXPECT_DOUBLE_EQ(s.current, 4.2);
     EXPECT_DOUBLE_EQ(s.duty_cycle, 0.157);
+}
+
+// Status 1's current field uses `static_cast<int16_t>(ntohs(...))`, so it
+// handles negative values correctly. Pinning this so a fix to
+// status_4/5/6 (which lack that cast) doesn't accidentally regress status_1.
+TEST_F(VescParameterGroupTest, DeserializesStatus1NegativeCurrent)
+{
+    const auto payload = concat({
+        be32(0),
+        be16(-42),  // current * 10 → -4.2 A
+        be16(0),
+    });
+    inject(addressing::drive::vesc::command_id::STATUS_1, payload);
+    EXPECT_DOUBLE_EQ(group->get_status1().current, -4.2);
 }
 
 // Status 2: amp-hours and amp-hours-charged, both int32 BE scaled by 10000.
@@ -157,10 +127,10 @@ TEST_F(VescParameterGroupTest, DeserializesStatus2)
     EXPECT_DOUBLE_EQ(s.ah_charge, 0.25);
 }
 
-// Status 4: temp_fet/temp_motor/current_in (int16 BE / 10), pid_pos (int16 BE / 50).
-// Only positive values exercised here — status_4's int16 fields drop the
-// `static_cast<int16_t>` after `ntohs` that status_1 has, so negative wire
-// values currently decode as huge positives. See
+// Status 4: temp_fet/temp_motor/current_in (int16 BE / 10), pid_pos (int16
+// BE / 50). Only positive values are exercised here — status_4's int16
+// fields drop the `static_cast<int16_t>` after `ntohs` that status_1 has,
+// so negative wire values currently decode as huge positives. See
 // DISABLED_DeserializesStatus4NegativeCurrentIn below.
 TEST_F(VescParameterGroupTest, DeserializesStatus4)
 {
@@ -177,7 +147,7 @@ TEST_F(VescParameterGroupTest, DeserializesStatus4)
     EXPECT_DOUBLE_EQ(s.temp_fet, 42.5);
     EXPECT_DOUBLE_EQ(s.temp_motor, 38.0);
     EXPECT_DOUBLE_EQ(s.current_in, 12.7);
-    EXPECT_DOUBLE_EQ(s.pid_pos, 180.0);
+    EXPECT_EQ(s.pid_pos, 180.0);
 }
 
 // status_4_t::deserialize_data computes `ntohs(raw_data.current_in) / 10.0`
@@ -185,12 +155,8 @@ TEST_F(VescParameterGroupTest, DeserializesStatus4)
 // sign bit is lost — a wire value of -127 (0xFF81) decodes as 65409, then
 // /10 = 6540.9. status_1 handles this correctly via
 // `static_cast<int16_t>(ntohs(...))`; the same fix is needed in
-// status_4_t/status_5_t/status_6_t (every int16 field that can be negative).
-//
-// Status1 also has a deserialize for negative current which DOES work — see
-// DeserializesStatus1NegativeCurrent below for the working case.
-//
-// When the cast is added, remove the DISABLED_ prefix.
+// status_4_t/status_5_t/status_6_t (every int16 field that can be
+// negative). When the cast is added, remove the DISABLED_ prefix.
 TEST_F(VescParameterGroupTest, DISABLED_DeserializesStatus4NegativeCurrentIn)
 {
     const auto payload = concat({
@@ -203,21 +169,8 @@ TEST_F(VescParameterGroupTest, DISABLED_DeserializesStatus4NegativeCurrentIn)
     EXPECT_DOUBLE_EQ(group->get_status4().current_in, -12.7);
 }
 
-// status_1's current field correctly handles negative values because its
-// deserialize uses `static_cast<int16_t>(ntohs(...))`. Pinning this so the
-// fix to status_4 doesn't accidentally regress status_1.
-TEST_F(VescParameterGroupTest, DeserializesStatus1NegativeCurrent)
-{
-    const auto payload = concat({
-        be32(0),
-        be16(-42),  // current * 10 → -4.2 A
-        be16(0),
-    });
-    inject(addressing::drive::vesc::command_id::STATUS_1, payload);
-    EXPECT_DOUBLE_EQ(group->get_status1().current, -4.2);
-}
-
-// Status 5: tachometer (int32 BE / 6), volts_in (int16 BE / 10), 2 bytes pad.
+// Status 5: tachometer (int32 BE / 6), volts_in (int16 BE / 10), 2 bytes
+// padding.
 TEST_F(VescParameterGroupTest, DeserializesStatus5)
 {
     const auto payload = concat({
@@ -229,8 +182,8 @@ TEST_F(VescParameterGroupTest, DeserializesStatus5)
     inject(addressing::drive::vesc::command_id::STATUS_5, payload);
 
     auto& s = group->get_status5();
-    EXPECT_DOUBLE_EQ(s.tachometer, 10000.0);
-    EXPECT_DOUBLE_EQ(s.volts_in, 48.0);
+    EXPECT_EQ(s.tachometer, 10000.0);
+    EXPECT_EQ(s.volts_in, 48.0);
 }
 
 // A frame addressed to a different VESC ID must not mutate this group.
@@ -238,39 +191,51 @@ TEST_F(VescParameterGroupTest, IgnoresFramesForOtherVescId)
 {
     using namespace addressing::drive::vesc;
     const auto other_address = static_cast<addressing::flagged_address_t>(
-        address_t(static_cast<uint8_t>(kVescId + 1), command_id::STATUS_1));
+        address_t(static_cast<uint8_t>(TEST_VESC_ID + 1), command_id::STATUS_1));
 
     bus.queue_receive(Packet{other_address, concat({be32(9999), be16(999), be16(999)})});
-    packet_manager->handle();
+    packet_manager->handle_receive();
 
     auto& s = group->get_status1();
-    EXPECT_DOUBLE_EQ(s.rpm, 0.0);
-    EXPECT_DOUBLE_EQ(s.current, 0.0);
-    EXPECT_DOUBLE_EQ(s.duty_cycle, 0.0);
+    EXPECT_EQ(s.rpm, 0.0);
+    EXPECT_EQ(s.current, 0.0);
+    EXPECT_EQ(s.duty_cycle, 0.0);
 }
 
 // Setting a SET_RPM value drives a transmission with the correct big-endian
-// scaled int32. set_rpm_t uses scaled_int32_t<1.0> so 2500 rpm → BE int32 2500.
+// scaled int32. set_rpm_t uses scaled_int32_t<1.0> so 2500 rpm → BE int32
+// 2500. We search the transmit queue by address rather than indexing into
+// it positionally, so the test stays robust when the group later registers
+// more transmissions.
 TEST_F(VescParameterGroupTest, SetRpmTransmitsScaledBigEndian)
 {
     using namespace addressing::drive::vesc;
 
     group->get_set_rpm().value = 2500.0;
-    // Force transmit regardless of interval.
     packet_manager->handle(/*should_block=*/false, /*should_force_transmission=*/true);
 
-    ASSERT_FALSE(bus.transmitted.empty()) << "expected at least one transmission";
-    const Packet& tx = bus.transmitted.front();
-    EXPECT_EQ(tx.get_address(),
-              static_cast<addressing::flagged_address_t>(address_t(kVescId, command_id::SET_RPM)));
-    EXPECT_EQ(tx.get_data(), be32(2500));
+    const auto set_rpm_address =
+        static_cast<addressing::flagged_address_t>(address_t(TEST_VESC_ID, command_id::SET_RPM));
+
+    bool found = false;
+    while (!bus.transmitted.empty())
+    {
+        const Packet& tx = bus.transmitted.front();
+        if (tx.get_address() == set_rpm_address)
+        {
+            EXPECT_EQ(tx.get_data(), be32(2500));
+            found = true;
+        }
+        bus.transmitted.pop();
+    }
+    EXPECT_TRUE(found) << "no SET_RPM transmission emitted";
 }
 
 // Round-trip is currently broken: status_*_t::serialize_data() in
 // hi_can_parameter.cpp applies htons/htonl BEFORE scaling
-// (e.g. `raw_data.current = htons(current) * 10.0;`) so serialize → deserialize
-// does NOT return the original value for any status struct except status_1's
-// rpm field (which has no fractional scaling).
+// (e.g. `raw_data.current = htons(current) * 10.0;`) so serialize →
+// deserialize does NOT return the original value for any status struct
+// except status_1's rpm field (which has no fractional scaling).
 //
 // When that serialize bug is fixed (multiply, then htons; see TODO in
 // status_5_t::serialize_data) remove the DISABLED_ prefix from this test.

--- a/software/shared/hi-can/tests/serializable_test.cpp
+++ b/software/shared/hi-can/tests/serializable_test.cpp
@@ -1,0 +1,253 @@
+// Unit tests for the foundational hi-can serialization primitives.
+//
+// Every device-specific ParameterGroup builds on these. If the primitives are
+// wrong, every downstream serializer is wrong silently.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include "hi_can_parameter.hpp"
+
+using namespace hi_can::parameters;
+
+// ---------- scaled_int32_t ------------------------------------------------
+
+// Helper: build the expected big-endian byte sequence for a given int32 value.
+static std::vector<uint8_t> be_bytes(int32_t v)
+{
+    return {
+        static_cast<uint8_t>((v >> 24) & 0xFF),
+        static_cast<uint8_t>((v >> 16) & 0xFF),
+        static_cast<uint8_t>((v >> 8) & 0xFF),
+        static_cast<uint8_t>(v & 0xFF),
+    };
+}
+static std::vector<uint8_t> be_bytes(int16_t v)
+{
+    return {
+        static_cast<uint8_t>((v >> 8) & 0xFF),
+        static_cast<uint8_t>(v & 0xFF),
+    };
+}
+
+TEST(ScaledInt32, SerializesAsBigEndian)
+{
+    scaled_int32_t<1.0> s;
+    s.value = 0x01020304;
+    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{0x01020304}));
+}
+
+TEST(ScaledInt32, AppliesScalingOnSerialize)
+{
+    // scaling factor 1000 means a value of 1.5 → 1500 on the wire
+    scaled_int32_t<1000.0> s;
+    s.value = 1.5;
+    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{1500}));
+}
+
+TEST(ScaledInt32, RoundsHalfAwayFromZero)
+{
+    // round() in <cmath> is "round half away from zero"
+    scaled_int32_t<1.0> s;
+    s.value = 0.5;
+    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{1}));
+    s.value = -0.5;
+    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{-1}));
+}
+
+TEST(ScaledInt32, HandlesNegativeValues)
+{
+    scaled_int32_t<10.0> s;
+    s.value = -3.2;
+    // -3.2 * 10 = -32 → big-endian int32
+    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{-32}));
+}
+
+TEST(ScaledInt32, DeserializeReversesScaling)
+{
+    scaled_int32_t<1000.0> s;
+    s.deserialize_data(be_bytes(int32_t{1500}));
+    EXPECT_DOUBLE_EQ(s.value, 1.5);
+}
+
+TEST(ScaledInt32, DeserializeHandlesNegatives)
+{
+    scaled_int32_t<10.0> s;
+    s.deserialize_data(be_bytes(int32_t{-32}));
+    EXPECT_DOUBLE_EQ(s.value, -3.2);
+}
+
+TEST(ScaledInt32, DeserializeHandlesZero)
+{
+    scaled_int32_t<1000.0> s;
+    s.deserialize_data(be_bytes(int32_t{0}));
+    EXPECT_DOUBLE_EQ(s.value, 0.0);
+}
+
+TEST(ScaledInt32, RoundTripsScaledValues)
+{
+    scaled_int32_t<100000.0> a;
+    a.value = 0.12345;
+    scaled_int32_t<100000.0> b;
+    b.deserialize_data(a.serialize_data());
+    EXPECT_DOUBLE_EQ(b.value, 0.12345);
+}
+
+TEST(ScaledInt32, ThrowsOnUndersizedInput)
+{
+    scaled_int32_t<1.0> s;
+    EXPECT_THROW(s.deserialize_data({0x00, 0x01, 0x02}), std::invalid_argument);
+}
+
+TEST(ScaledInt32, ThrowsOnOversizedInput)
+{
+    scaled_int32_t<1.0> s;
+    EXPECT_THROW(s.deserialize_data({0, 0, 0, 0, 0}), std::invalid_argument);
+}
+
+// ---------- scaled_int16_t ------------------------------------------------
+
+TEST(ScaledInt16, SerializesAsBigEndian)
+{
+    scaled_int16_t<1.0> s;
+    s.value = 0x0102;
+    EXPECT_EQ(s.serialize_data(), be_bytes(int16_t{0x0102}));
+}
+
+TEST(ScaledInt16, AppliesScalingOnSerialize)
+{
+    scaled_int16_t<10.0> s;
+    s.value = 12.7;
+    EXPECT_EQ(s.serialize_data(), be_bytes(int16_t{127}));
+}
+
+TEST(ScaledInt16, HandlesNegativeValues)
+{
+    scaled_int16_t<10.0> s;
+    s.value = -3.2;
+    EXPECT_EQ(s.serialize_data(), be_bytes(int16_t{-32}));
+}
+
+TEST(ScaledInt16, RoundTripsAcrossSignFlip)
+{
+    scaled_int16_t<50.0> a;
+    a.value = -10.5;
+    scaled_int16_t<50.0> b;
+    b.deserialize_data(a.serialize_data());
+    EXPECT_DOUBLE_EQ(b.value, -10.5);
+}
+
+TEST(ScaledInt16, ThrowsOnWrongSize)
+{
+    scaled_int16_t<1.0> s;
+    EXPECT_THROW(s.deserialize_data({0x00}), std::invalid_argument);
+    EXPECT_THROW(s.deserialize_data({0x00, 0x01, 0x02}), std::invalid_argument);
+}
+
+// ---------- SimpleSerializable<T> -----------------------------------------
+//
+// SimpleSerializable is a raw memcpy of a packed POD struct in NATIVE byte
+// order. This is intentionally distinct from scaled_int{16,32}_t which use
+// network byte order. Mixing them up is a common bug source — the tests below
+// pin the layout.
+
+namespace
+{
+#pragma pack(push, 1)
+    struct probe_pod_t
+    {
+        uint8_t a;
+        uint16_t b;
+        int8_t c;
+    };
+#pragma pack(pop)
+}  // namespace
+
+TEST(SimpleSerializable, RoundTripsPodStruct)
+{
+    SimpleSerializable<probe_pod_t> in;
+    in.a = 0xAB;
+    in.b = 0x1234;
+    in.c = -7;
+
+    SimpleSerializable<probe_pod_t> out(in.serialize_data());
+
+    EXPECT_EQ(out.a, 0xAB);
+    EXPECT_EQ(out.b, 0x1234);
+    EXPECT_EQ(out.c, -7);
+}
+
+TEST(SimpleSerializable, ProducesPackedSize)
+{
+    // probe_pod_t: 1 + 2 + 1 = 4 bytes, packed.
+    SimpleSerializable<probe_pod_t> s;
+    s.a = 0;
+    s.b = 0;
+    s.c = 0;
+    EXPECT_EQ(s.serialize_data().size(), 4u);
+}
+
+TEST(SimpleSerializable, UsesNativeByteOrder)
+{
+    // Pin this to little-endian. Every platform the rover runs on (x86_64,
+    // aarch64, armhf) is little-endian; if we ever land on a big-endian host
+    // this test will (correctly) fail and force us to revisit the wire format.
+    SimpleSerializable<probe_pod_t> s;
+    s.a = 0x11;
+    s.b = 0x2233;  // little-endian → 0x33, 0x22
+    s.c = 0x44;
+
+    const std::vector<uint8_t> expected = {0x11, 0x33, 0x22, 0x44};
+    EXPECT_EQ(s.serialize_data(), expected);
+}
+
+TEST(SimpleSerializable, ThrowsOnSizeMismatch)
+{
+    SimpleSerializable<probe_pod_t> s;
+    EXPECT_THROW(s.deserialize_data({0x00, 0x01, 0x02}), std::invalid_argument);
+    EXPECT_THROW(s.deserialize_data({0, 0, 0, 0, 0}), std::invalid_argument);
+}
+
+// ---------- wrapped_value_t<T> + SimpleSerializable ------------------------
+//
+// Used by every PWM / position / bool parameter in the codebase. This is the
+// pattern arm and bucket controllers all follow.
+
+TEST(WrappedValue, RoundTripsUint16)
+{
+    SimpleSerializable<wrapped_value_t<uint16_t>> in;
+    in.value = 0xCAFE;
+    SimpleSerializable<wrapped_value_t<uint16_t>> out(in.serialize_data());
+    EXPECT_EQ(out.value, 0xCAFE);
+}
+
+TEST(WrappedValue, RoundTripsInt16Negative)
+{
+    SimpleSerializable<wrapped_value_t<int16_t>> in;
+    in.value = -12345;
+    SimpleSerializable<wrapped_value_t<int16_t>> out(in.serialize_data());
+    EXPECT_EQ(out.value, -12345);
+}
+
+TEST(WrappedValue, RoundTripsUint8)
+{
+    SimpleSerializable<wrapped_value_t<uint8_t>> in;
+    in.value = 0x7F;
+    SimpleSerializable<wrapped_value_t<uint8_t>> out(in.serialize_data());
+    EXPECT_EQ(out.value, 0x7F);
+}
+
+TEST(WrappedValue, RoundTripsBool)
+{
+    SimpleSerializable<wrapped_value_t<bool>> in;
+    in.value = true;
+    auto bytes = in.serialize_data();
+    ASSERT_EQ(bytes.size(), 1u);
+    EXPECT_EQ(bytes[0], 0x01);
+
+    SimpleSerializable<wrapped_value_t<bool>> out(bytes);
+    EXPECT_TRUE(out.value);
+}

--- a/software/shared/hi-can/tests/serializable_test.cpp
+++ b/software/shared/hi-can/tests/serializable_test.cpp
@@ -5,85 +5,70 @@
 
 #include <gtest/gtest.h>
 
+#include <bit>
 #include <cstdint>
 #include <stdexcept>
 #include <vector>
 
 #include "hi_can_parameter.hpp"
+#include "test_helpers.hpp"
 
 using namespace hi_can::parameters;
+using hi_can_test::be16;
+using hi_can_test::be32;
 
 // ---------- scaled_int32_t ------------------------------------------------
-
-// Helper: build the expected big-endian byte sequence for a given int32 value.
-static std::vector<uint8_t> be_bytes(int32_t v)
-{
-    return {
-        static_cast<uint8_t>((v >> 24) & 0xFF),
-        static_cast<uint8_t>((v >> 16) & 0xFF),
-        static_cast<uint8_t>((v >> 8) & 0xFF),
-        static_cast<uint8_t>(v & 0xFF),
-    };
-}
-static std::vector<uint8_t> be_bytes(int16_t v)
-{
-    return {
-        static_cast<uint8_t>((v >> 8) & 0xFF),
-        static_cast<uint8_t>(v & 0xFF),
-    };
-}
 
 TEST(ScaledInt32, SerializesAsBigEndian)
 {
     scaled_int32_t<1.0> s;
     s.value = 0x01020304;
-    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{0x01020304}));
+    EXPECT_EQ(s.serialize_data(), be32(0x01020304));
 }
 
 TEST(ScaledInt32, AppliesScalingOnSerialize)
 {
-    // scaling factor 1000 means a value of 1.5 → 1500 on the wire
+    // Scaling factor 1000 means a value of 1.5 → 1500 on the wire.
     scaled_int32_t<1000.0> s;
     s.value = 1.5;
-    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{1500}));
+    EXPECT_EQ(s.serialize_data(), be32(1500));
 }
 
 TEST(ScaledInt32, RoundsHalfAwayFromZero)
 {
-    // round() in <cmath> is "round half away from zero"
+    // round() in <cmath> is "round half away from zero".
     scaled_int32_t<1.0> s;
     s.value = 0.5;
-    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{1}));
+    EXPECT_EQ(s.serialize_data(), be32(1));
     s.value = -0.5;
-    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{-1}));
+    EXPECT_EQ(s.serialize_data(), be32(-1));
 }
 
 TEST(ScaledInt32, HandlesNegativeValues)
 {
     scaled_int32_t<10.0> s;
     s.value = -3.2;
-    // -3.2 * 10 = -32 → big-endian int32
-    EXPECT_EQ(s.serialize_data(), be_bytes(int32_t{-32}));
+    EXPECT_EQ(s.serialize_data(), be32(-32));
 }
 
 TEST(ScaledInt32, DeserializeReversesScaling)
 {
     scaled_int32_t<1000.0> s;
-    s.deserialize_data(be_bytes(int32_t{1500}));
+    s.deserialize_data(be32(1500));
     EXPECT_DOUBLE_EQ(s.value, 1.5);
 }
 
 TEST(ScaledInt32, DeserializeHandlesNegatives)
 {
     scaled_int32_t<10.0> s;
-    s.deserialize_data(be_bytes(int32_t{-32}));
+    s.deserialize_data(be32(-32));
     EXPECT_DOUBLE_EQ(s.value, -3.2);
 }
 
 TEST(ScaledInt32, DeserializeHandlesZero)
 {
     scaled_int32_t<1000.0> s;
-    s.deserialize_data(be_bytes(int32_t{0}));
+    s.deserialize_data(be32(0));
     EXPECT_DOUBLE_EQ(s.value, 0.0);
 }
 
@@ -114,21 +99,21 @@ TEST(ScaledInt16, SerializesAsBigEndian)
 {
     scaled_int16_t<1.0> s;
     s.value = 0x0102;
-    EXPECT_EQ(s.serialize_data(), be_bytes(int16_t{0x0102}));
+    EXPECT_EQ(s.serialize_data(), be16(0x0102));
 }
 
 TEST(ScaledInt16, AppliesScalingOnSerialize)
 {
     scaled_int16_t<10.0> s;
     s.value = 12.7;
-    EXPECT_EQ(s.serialize_data(), be_bytes(int16_t{127}));
+    EXPECT_EQ(s.serialize_data(), be16(127));
 }
 
 TEST(ScaledInt16, HandlesNegativeValues)
 {
     scaled_int16_t<10.0> s;
     s.value = -3.2;
-    EXPECT_EQ(s.serialize_data(), be_bytes(int16_t{-32}));
+    EXPECT_EQ(s.serialize_data(), be16(-32));
 }
 
 TEST(ScaledInt16, RoundTripsAcrossSignFlip)
@@ -151,17 +136,17 @@ TEST(ScaledInt16, ThrowsOnWrongSize)
 //
 // SimpleSerializable is a raw memcpy of a packed POD struct in NATIVE byte
 // order. This is intentionally distinct from scaled_int{16,32}_t which use
-// network byte order. Mixing them up is a common bug source — the tests below
-// pin the layout.
+// network byte order. Mixing them up is a common bug source — the tests
+// below pin the layout.
 
 namespace
 {
 #pragma pack(push, 1)
     struct probe_pod_t
     {
-        uint8_t a;
-        uint16_t b;
-        int8_t c;
+        uint8_t first;
+        uint16_t second;
+        int8_t third;
     };
 #pragma pack(pop)
 }  // namespace
@@ -169,36 +154,41 @@ namespace
 TEST(SimpleSerializable, RoundTripsPodStruct)
 {
     SimpleSerializable<probe_pod_t> in;
-    in.a = 0xAB;
-    in.b = 0x1234;
-    in.c = -7;
+    in.first = 0xAB;
+    in.second = 0x1234;
+    in.third = -7;
 
     SimpleSerializable<probe_pod_t> out(in.serialize_data());
 
-    EXPECT_EQ(out.a, 0xAB);
-    EXPECT_EQ(out.b, 0x1234);
-    EXPECT_EQ(out.c, -7);
+    EXPECT_EQ(out.first, 0xAB);
+    EXPECT_EQ(out.second, 0x1234);
+    EXPECT_EQ(out.third, -7);
 }
 
 TEST(SimpleSerializable, ProducesPackedSize)
 {
     // probe_pod_t: 1 + 2 + 1 = 4 bytes, packed.
     SimpleSerializable<probe_pod_t> s;
-    s.a = 0;
-    s.b = 0;
-    s.c = 0;
+    s.first = 0;
+    s.second = 0;
+    s.third = 0;
     EXPECT_EQ(s.serialize_data().size(), 4u);
 }
 
-TEST(SimpleSerializable, UsesNativeByteOrder)
+TEST(SimpleSerializable, UsesLittleEndianOnLittleEndianHosts)
 {
-    // Pin this to little-endian. Every platform the rover runs on (x86_64,
-    // aarch64, armhf) is little-endian; if we ever land on a big-endian host
-    // this test will (correctly) fail and force us to revisit the wire format.
+    // SimpleSerializable is a raw memcpy, so the bytes appear in the host's
+    // native byte order. Every platform the rover runs on (x86_64, aarch64,
+    // armhf) is little-endian, so we pin to that here. If a future port
+    // lands on a big-endian host, this test fires loudly and the wire format
+    // must be revisited (it would silently change otherwise).
+    if constexpr (std::endian::native != std::endian::little)
+        GTEST_SKIP() << "Host is not little-endian; SimpleSerializable wire format would diverge.";
+
     SimpleSerializable<probe_pod_t> s;
-    s.a = 0x11;
-    s.b = 0x2233;  // little-endian → 0x33, 0x22
-    s.c = 0x44;
+    s.first = 0x11;
+    s.second = 0x2233;  // little-endian → 0x33, 0x22
+    s.third = 0x44;
 
     const std::vector<uint8_t> expected = {0x11, 0x33, 0x22, 0x44};
     EXPECT_EQ(s.serialize_data(), expected);
@@ -250,4 +240,54 @@ TEST(WrappedValue, RoundTripsBool)
 
     SimpleSerializable<wrapped_value_t<bool>> out(bytes);
     EXPECT_TRUE(out.value);
+}
+
+TEST(WrappedValue, DefaultConstructsToZero)
+{
+    SimpleSerializable<wrapped_value_t<uint16_t>> s;
+    EXPECT_EQ(s.value, 0u);
+}
+
+// ---------- bucket_controller wire format ---------------------------------
+//
+// excavation::bucket::controller::{speed_t, current_t, magnet_t} are real
+// device typedefs of SimpleSerializable<wrapped_value_t<T>>. Pinning their
+// wire layout here serves as the worked example for arm end-effector PWM
+// (which is the same pattern: SimpleSerializable<wrapped_value_t<uint16_t>>).
+
+TEST(BucketControllerWire, SpeedIsLittleEndianInt16)
+{
+    if constexpr (std::endian::native != std::endian::little)
+        GTEST_SKIP() << "Host is not little-endian.";
+
+    excavation::bucket::controller::speed_t s;
+    s.value = 1234;  // 0x04D2 little-endian → {0xD2, 0x04}
+    EXPECT_EQ(s.serialize_data(), (std::vector<uint8_t>{0xD2, 0x04}));
+}
+
+TEST(BucketControllerWire, SpeedNegativeRoundTrips)
+{
+    excavation::bucket::controller::speed_t a;
+    a.value = -2048;
+    excavation::bucket::controller::speed_t b(a.serialize_data());
+    EXPECT_EQ(b.value, -2048);
+}
+
+TEST(BucketControllerWire, CurrentIsLittleEndianUint16)
+{
+    if constexpr (std::endian::native != std::endian::little)
+        GTEST_SKIP() << "Host is not little-endian.";
+
+    excavation::bucket::controller::current_t c;
+    c.value = 0xBEEF;
+    EXPECT_EQ(c.serialize_data(), (std::vector<uint8_t>{0xEF, 0xBE}));
+}
+
+TEST(BucketControllerWire, MagnetIsSingleByteBool)
+{
+    excavation::bucket::controller::magnet_t m;
+    m.value = true;
+    EXPECT_EQ(m.serialize_data(), (std::vector<uint8_t>{0x01}));
+    m.value = false;
+    EXPECT_EQ(m.serialize_data(), (std::vector<uint8_t>{0x00}));
 }

--- a/software/shared/hi-can/tests/test_helpers.hpp
+++ b/software/shared/hi-can/tests/test_helpers.hpp
@@ -1,0 +1,45 @@
+// Shared helpers for hi-can unit tests.
+//
+// Defines big-endian byte builders and a concat for assembling golden CAN
+// payloads. Always source golden bytes from the device datasheet (or from
+// hand-computed scaling factors), not by round-tripping through the code
+// under test — otherwise a bug in the serializer hides itself.
+
+#pragma once
+
+#include <cstdint>
+#include <initializer_list>
+#include <vector>
+
+namespace hi_can_test
+{
+    inline std::vector<uint8_t> be32(int32_t v)
+    {
+        // Cast to unsigned so the right-shifts are unambiguously logical,
+        // not implementation-defined arithmetic on signed integers.
+        const uint32_t u = static_cast<uint32_t>(v);
+        return {
+            static_cast<uint8_t>((u >> 24) & 0xFFu),
+            static_cast<uint8_t>((u >> 16) & 0xFFu),
+            static_cast<uint8_t>((u >> 8) & 0xFFu),
+            static_cast<uint8_t>(u & 0xFFu),
+        };
+    }
+
+    inline std::vector<uint8_t> be16(int16_t v)
+    {
+        const uint16_t u = static_cast<uint16_t>(v);
+        return {
+            static_cast<uint8_t>((u >> 8) & 0xFFu),
+            static_cast<uint8_t>(u & 0xFFu),
+        };
+    }
+
+    inline std::vector<uint8_t> concat(std::initializer_list<std::vector<uint8_t>> parts)
+    {
+        std::vector<uint8_t> out;
+        for (const auto& p : parts)
+            out.insert(out.end(), p.begin(), p.end());
+        return out;
+    }
+}  // namespace hi_can_test


### PR DESCRIPTION
## Summary

Finishes the GoogleTest scaffolding that was already half set up in `software/shared/hi-can/`. The `tests/` directory existed, gtest was in `default.nix`'s `nativeBuildInputs` with `doCheck = true`, and the CMake testing block was sitting commented out. This PR lands an actual test suite on top.

45 tests total. 43 active, 2 deliberately `DISABLED_`. 100% passing under `nix build .#pkgs.hi-can`.

## What's covered

- **Serialization primitives** (`tests/serializable_test.cpp`)
  - `scaled_int32_t` and `scaled_int16_t`: round-trip, big-endian wire format, scaling, negatives, size-mismatch throws, half-away-from-zero rounding.
  - `SimpleSerializable<T>`: round-trip a packed POD, exact packed size, native byte order pinned to LE with a `GTEST_SKIP` on BE hosts.
  - `wrapped_value_t<T>`: uint8 / uint16 / int16 / bool round-trip plus default-init zero.
  - `bucket_controller::{speed_t, current_t, magnet_t}`: pins the LE wire format for the `SimpleSerializable<wrapped_value_t<T>>` pattern that the arm end-effector PWM in #436 reuses.
- **VESC parameter group** (`tests/parameter_group_test.cpp`)
  - Golden-byte deserialize for status_1, status_2, status_4, status_5.
  - `SET_RPM` transmit test (searches the transmitted queue by address rather than indexing positionally, so it survives more transmissions being added later).
  - Cross-VESC-ID isolation.
  - Negative-current handling on status_1 pinned so a fix to status_4 / 5 / 6 can't regress status_1.
- **Legacy drive ESC parameter group** (`tests/esc_parameter_group_test.cpp`)
  - `StartupTransmissionsRequestsLimits`: pins that `get_startup_transmissions()` emits the LIMITS RTR packet. This is the direct regression catcher for the silent functional regression introduced in #436 when the body of that method got commented out during a namespace clash.
  - Speed and status deserialize plus cross-device isolation.
- **Filter matching** (`tests/filter_test.cpp`)
  - Exact match rejects different addresses.
  - `DEVICE_MASK` matches all groups and parameters on a device, rejects other devices and subsystems.
  - End-to-end `PacketManager` dispatch through a masked filter.
  - More-specific filter wins on overlap.

Shared test infrastructure: `tests/test_helpers.hpp` (`be32`, `be16`, `concat`) and `tests/mock_can_interface.hpp` (`FifoCanInterface`).

`tests/README.md` documents the pattern for adding a new device's tests, including the easy-to-miss requirement to `git add` new test files before `nix build` will see them (the flake source filter uses `git ls-files`).

## Two latent bugs the tests surfaced

Both are flagged as `DISABLED_` tests with a clear comment pointing at the fix. When the underlying code is fixed, the test author just removes the `DISABLED_` prefix.

1. **`status_*_t::serialize_data()` applies `htons` / `htonl` before scaling.** For example `raw_data.current = htons(current) * 10.0;`. Serialize then deserialize does not round-trip for any fractional value. Captured by `VescParameterGroupTest.DISABLED_Status1RoundTripsThroughSerialize`. The TODO already sitting in `status_5_t::serialize_data` flags the same root cause.
2. **`status_4_t`, `status_5_t`, `status_6_t` deserialize drops the `static_cast<int16_t>` after `ntohs`** that `status_1_t` correctly has. Wire value `-127` (`0xFF81`) decodes as `65409`, divided by 10 gives `6540.9` instead of `-12.7`. Affects `current_in`, `volts_in`, and all of status_6's ADC fields. Captured by `VescParameterGroupTest.DISABLED_DeserializesStatus4NegativeCurrentIn`.

Neither bug is fixed in this PR. The tests exist to make the bugs visible and to fail loudly when they're fixed and someone re-enables the tests.

## Not yet covered

`PacketManager::callback_config_t::{timeout, timeout_callback, timeout_recovery_callback}` is real production machinery used by `bucket_driver` and others, but `handle_receive` reads `steady_clock::now()` directly. Testing it cleanly needs either a clock abstraction injected into `PacketManager` or a flaky `sleep_for`. Deferred until that refactor is done.

## Test plan

- [ ] `nix build .#pkgs.hi-can` succeeds and runs all 43 active tests green, 2 `DISABLED_` skipped as expected.
- [ ] Local `cmake -B build -DBUILD_TESTING=ON && cmake --build build && ctest --test-dir build --output-on-failure` from inside `nix develop` also passes.
- [ ] Confirm the two `DISABLED_` tests fail loudly if the `DISABLED_` prefix is removed locally and the corresponding production bug isn't fixed.