### PR TITLE
Review fixes for #442: strip non-portable -march=native, correct license

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,0 +1,21 @@
+# Error Pattern Log
+
+### Non-portable `-march=native` baked into a binary-cached Nix package — 2026-06-19
+
+- **Severity:** High
+- **Category:** Configuration
+- **File(s):** `software/ros_ws/third-party-packages/vikit-common/default.nix` (upstream `vikit_common/CMakeLists.txt`)
+- **Pattern:** Vendored third-party CMake projects that hardcode `-march=native` (or other host-specific `-mtune=native`/auto-ISA flags) in `CMAKE_CXX_FLAGS`. When the artifact is built on CI and pulled from a binary cache onto different hardware, the baked-in ISA can trigger `SIGILL` (illegal instruction) at runtime. Also makes the build non-reproducible.
+- **Root cause:** Upstream `vikit_common` targets a single known machine and optimizes for it; that assumption is invalid for a shared/cached Nix derivation deployed to heterogeneous robot CPUs.
+- **Fix applied:** Added `--replace-warn "-march=native " ""` to the package's `postPatch`, stripping the flag while keeping the architecture-gated `-msse*` / `-march=armv8-a` baseline flags the CMakeLists already sets.
+- **Prevention rule:** When packaging a third-party CMake project for the Nix/cachix workspace, grep its `CMakeLists.txt` for `native` and strip `-march=native`/`-mtune=native` in `postPatch`. Never let host-detected ISA flags into a cached derivation.
+
+### ROS `package.xml` "GPLv3" mapped to `gpl3Plus` instead of `gpl3Only` — 2026-06-19
+
+- **Severity:** Low
+- **Category:** Convention
+- **File(s):** `software/ros_ws/third-party-packages/vikit-common/default.nix`, `software/ros_ws/third-party-packages/vikit-ros/default.nix`
+- **Pattern:** Setting `meta.license = gpl3Plus` when the upstream license statement is bare "GPLv3" with no "or later" clause. `gpl3Plus` (GPL-3.0-or-later) over-states the granted rights.
+- **Root cause:** Loose habit of defaulting to the `*Plus` license attribute without checking for an explicit "or later" clause.
+- **Fix applied:** Changed both packages to `gpl3Only`, matching the `<license>GPLv3</license>` declared in each `package.xml` (no LICENSE file or "or later" text exists upstream).
+- **Prevention rule:** Map a bare "GPLvN" / "GPL-N.0" declaration to `gpl<N>Only`; only use `gpl<N>Plus` when the source explicitly says "or (at your option) any later version".

--- a/software/ros_ws/third-party-packages/vikit-common/default.nix
+++ b/software/ros_ws/third-party-packages/vikit-common/default.nix
@@ -37,10 +37,17 @@ buildRosPackage {
 
   # Upstream hardcodes -std=c++0x (C++11), but Sophus 1.24.6 headers require
   # C++14/17 (std::enable_if_t). Bump to C++17 to match vikit_ros.
+  #
+  # Also strip `-march=native`: it bakes the build machine's ISA into the
+  # artifact, which breaks reproducibility and risks SIGILL when a binary-cached
+  # build (e.g. from CI) is run on robot hardware with a different CPU. The
+  # x86/ARM baseline `-msse*/-march=armv8-a` flags the CMakeLists already sets
+  # for each architecture are kept.
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-warn "-std=c++0x" "-std=c++17" \
-      --replace-warn "-std=c++11" "-std=c++17"
+      --replace-warn "-std=c++11" "-std=c++17" \
+      --replace-warn "-march=native " ""
   '';
 
   buildType = "ament_cmake";
@@ -69,6 +76,7 @@ buildRosPackage {
 
   meta = {
     description = "Vikit common: camera models, math and interpolation utilities (ROS2 port)";
-    license = with lib.licenses; [ gpl3Plus ];
+    # Upstream package.xml declares "GPLv3" with no "or later" clause -> GPL-3.0-only.
+    license = with lib.licenses; [ gpl3Only ];
   };
 }

--- a/software/ros_ws/third-party-packages/vikit-ros/default.nix
+++ b/software/ros_ws/third-party-packages/vikit-ros/default.nix
@@ -58,6 +58,7 @@ buildRosPackage {
 
   meta = {
     description = "Vikit ROS2 integration: camera parameter handling and ROS utilities";
-    license = with lib.licenses; [ gpl3Plus ];
+    # Upstream package.xml declares "GPLv3" with no "or later" clause -> GPL-3.0-only.
+    license = with lib.licenses; [ gpl3Only ];
   };
 }


### PR DESCRIPTION
Review fixes stacked on top of #442 (`feat/add-vikit-package`). The base PR's packaging is sound; these are two correctness fixes found during review. Both packages and the `default` workspace still build/evaluate cleanly.

## Changes

- **High — strip `-march=native`** from `vikit_common`. Its upstream `CMakeLists.txt` bakes `-march=native` into `CMAKE_CXX_FLAGS`. For a binary-cached Nix derivation this is non-reproducible and risks `SIGILL` when a CI-built artifact runs on robot hardware with a different CPU. Removed it in `postPatch`; the architecture-gated `-msse*` / `-march=armv8-a` baselines the CMakeLists already sets per-arch are kept.
- **Low — license accuracy.** Both `package.xml` files declare bare `GPLv3` (no "or later" clause, no LICENSE file upstream), so `gpl3Plus` → `gpl3Only` in both derivations.
- Logged both patterns to `ERRORS.md` per project convention.

## Testing

```
nix build .#pkgs.ros.vikit-common .#pkgs.ros.vikit-ros   # ✅ both build
nix eval  .#default.drvPath                              # ✅ full workspace evaluates
nix fmt                                                   # ✅ 0 changed
```

Verified in the built output:
- `libvikit_common.so`, `libvikit_ros.so` present
- relocatable `lib/cmake/vikit_common/vikit_commonConfig.cmake` present
- `vikit_ros` registered in the ament index; `vikit-ros` links against the patched `vikit-common`

## Review notes (no change needed)

- Dropping `cmake_modules` is correct — `vikit_common` resolves Eigen via its bundled `CMakeModules/FindEigen.cmake`; `vikit_ros` uses the standard `Eigen3`/`Sophus`/`OpenCV` configs.
- `rosidl_default_generators`/`runtime` are kept because `vikit_ros`'s CMakeLists does `find_package(rosidl_default_generators REQUIRED)`, even though no interfaces are generated.
- The `vikit_commonConfig.cmake` heredoc works because Nix's `''` string strips the common indentation (including the `EOF` terminator) uniformly.